### PR TITLE
feat: onboarding welcome screen for new users

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,8 +13,38 @@
       </template>
     </AppHeader>
 
+    <!-- Welcome Screen: shown on first load when no saved data exists -->
+    <div v-if="showWelcome" class="welcome-screen">
+      <div class="welcome-card">
+        <div class="welcome-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="16" y1="13" x2="8" y2="13" />
+            <line x1="16" y1="17" x2="8" y2="17" />
+            <polyline points="10 9 9 9 8 9" />
+          </svg>
+        </div>
+        <h2 class="welcome-headline">
+          Create professional documents in seconds
+        </h2>
+        <p class="welcome-description">
+          Write structured XML, pick a template, and instantly preview a polished document — ready to export.
+        </p>
+        <UButton
+          size="xl"
+          color="primary"
+          class="welcome-cta"
+          :loading="isSampleLoading"
+          @click="loadSample"
+        >
+          Start with a sample
+        </UButton>
+      </div>
+    </div>
+
     <!-- Dual-panel layout: Editor (left) and Preview (right) -->
-    <div class="dual-panel-layout">
+    <div v-else class="dual-panel-layout">
       <!-- Left Panel: XML Editor -->
       <div class="editor-panel">
         <XmlEditor
@@ -41,24 +71,24 @@ import { ref, watch, onMounted, onUnmounted } from 'vue'
 /**
  * Main Application Page - MVP 6: Dual-Panel Integration
  *
- * This page brings together all MVPs 1-5:
- * - AppHeader (MVP 1) with title and empty action slots
- * - XML Parser (MVP 2) via PreviewPanel
- * - Template System (MVP 3) via PreviewPanel
- * - XmlEditor (MVP 4) for editing
- * - PreviewPanel (MVP 5) for real-time preview
- *
  * Features:
+ * - Welcome screen on first load (no saved data in localStorage)
  * - Dual-panel 50/50 layout (CSS Grid)
  * - 300ms debounced real-time updates (per DECISIONS.md)
- * - Auto-loads sample XML from /samples/cover-letter.xml
+ * - Persists XML content to localStorage
  * - Minimum 1024px responsive design
  */
+
+const LS_KEY = 'ohmydoc_xml_content'
 
 // Set page metadata
 useHead({
   title: 'OhMyDoc - XML to HTML Transformer',
 })
+
+// Welcome screen is shown when no saved data exists
+const showWelcome = ref(true)
+const isSampleLoading = ref(false)
 
 // Reactive state for XML content
 const xmlContent = ref('')
@@ -73,54 +103,68 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null
  * without feeling laggy or causing excessive re-parsing
  */
 watch(xmlContent, (newValue) => {
-  // Clear existing timer
   if (debounceTimer) {
     clearTimeout(debounceTimer)
   }
 
-  // Set new timer for 300ms debounce
   debounceTimer = setTimeout(() => {
     debouncedXmlContent.value = newValue
+    // Persist to localStorage so returning users skip the welcome screen
+    try {
+      localStorage.setItem(LS_KEY, newValue)
+    }
+    catch {
+      // Ignore storage errors (private browsing, quota exceeded, etc.)
+    }
   }, 300)
 })
 
 /**
- * Load sample XML on page mount
- * Fetches /samples/cover-letter.xml from public directory
+ * Fetch and apply the sample cover letter XML.
+ * Called by the "Start with a sample" button on the welcome screen.
  */
-onMounted(async () => {
+async function loadSample() {
+  isSampleLoading.value = true
   try {
     const response = await fetch('/samples/cover-letter.xml')
-
     if (!response.ok) {
-      throw new Error(`Failed to load sample XML: ${response.statusText}`)
+      throw new Error(`HTTP ${response.status}`)
     }
-
     const sampleXml = await response.text()
-
-    // Set both content refs - debounced will update via watcher
     xmlContent.value = sampleXml
     debouncedXmlContent.value = sampleXml
+    showWelcome.value = false
   }
   catch (error) {
     console.error('Error loading sample XML:', error)
+    // Still dismiss welcome and show an empty editor rather than getting stuck
+    showWelcome.value = false
+  }
+  finally {
+    isSampleLoading.value = false
+  }
+}
 
-    // Provide fallback empty XML structure if sample fails to load
-    const fallbackXml = `<?xml version="1.0" encoding="UTF-8"?>
-<applicationDocument>
-  <applicant>
-    <name>Your Name</name>
-  </applicant>
-</applicationDocument>`
-
-    xmlContent.value = fallbackXml
-    debouncedXmlContent.value = fallbackXml
+/**
+ * On mount: restore saved content from localStorage.
+ * If content exists, skip the welcome screen and load it directly.
+ */
+onMounted(() => {
+  try {
+    const saved = localStorage.getItem(LS_KEY)
+    if (saved) {
+      xmlContent.value = saved
+      debouncedXmlContent.value = saved
+      showWelcome.value = false
+    }
+  }
+  catch {
+    // Ignore localStorage errors; welcome screen will show as default
   }
 })
 
 /**
  * Cleanup: Clear debounce timer on component unmount
- * Prevents memory leaks if component unmounts during debounce window
  */
 onUnmounted(() => {
   if (debounceTimer) {
@@ -195,5 +239,50 @@ onUnmounted(() => {
     border-right: none;
     border-bottom: 1px solid var(--color-gray-300);
   }
+}
+
+/**
+ * Welcome screen - shown on first load
+ */
+.welcome-screen {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-gray-50);
+  padding: 2rem;
+}
+
+.welcome-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  max-width: 480px;
+  gap: 1.25rem;
+}
+
+.welcome-icon {
+  color: var(--color-primary-500, #0f6fec);
+  opacity: 0.85;
+}
+
+.welcome-headline {
+  font-size: 1.75rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--color-gray-900);
+  margin: 0;
+}
+
+.welcome-description {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: var(--color-gray-600);
+  margin: 0;
+}
+
+.welcome-cta {
+  margin-top: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- Show a welcome screen instead of a blank editor when no saved document exists in localStorage
- Welcome screen has a headline, description, and a "Start with a sample" CTA button
- Clicking the button fetches the cover-letter XML, populates the editor, and transitions to the dual-panel view
- Returning users with existing localStorage data bypass the welcome screen and go straight to the editor

## Behaviour
| Scenario | Result |
|----------|--------|
| First visit (no localStorage) | Welcome screen shown |
| Click "Start with a sample" | Sample XML loaded, editor + preview displayed |
| Return visit (localStorage key `ohmydoc_xml_content` present) | Welcome screen skipped, editor loaded with saved content |

## Test plan
- [ ] Clear localStorage and open the app — welcome screen appears
- [ ] Click "Start with a sample" — editor loads with cover letter XML and preview renders
- [ ] Reload the page — welcome screen is skipped, previous content is restored
- [ ] Test in private/incognito window (localStorage unavailable) — welcome screen shows, button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)