### PR TITLE
feat: add UI template switcher dropdown in header

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -16,8 +16,21 @@
         </p>
       </div>
 
-      <!-- Right action slot for future buttons (Export, Zoom - MVPs 7 & 9) -->
-      <div class="flex items-center gap-2">
+      <!-- Right: Template switcher + action slot (Export, Zoom - MVPs 7 & 9) -->
+      <div class="flex items-center gap-3">
+        <!-- Template Switcher Dropdown -->
+        <div class="flex items-center gap-2">
+          <label class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Template:</label>
+          <USelectMenu
+            v-model="selectedTemplate"
+            :options="templateOptions"
+            value-attribute="value"
+            option-attribute="label"
+            size="sm"
+            class="w-32"
+          />
+        </div>
+
         <slot name="right-actions" />
       </div>
     </div>
@@ -25,8 +38,15 @@
 </template>
 
 <script setup lang="ts">
-// AppHeader component using @nuxt/ui
-// Provides app title and empty action slots for future features
-// - Left slot: Format, Clear, Import buttons (MVP 8)
-// - Right slot: Export and Zoom buttons (MVPs 7 & 9)
+import { computed } from 'vue'
+import { useTemplate } from '~/composables/useTemplate'
+
+const { activeTemplate, setActiveTemplate, getAllTemplateMetadata } = useTemplate()
+
+const templateOptions = getAllTemplateMetadata().map(m => ({ label: m.displayName, value: m.name }))
+
+const selectedTemplate = computed({
+  get: () => activeTemplate.value,
+  set: (val: string) => setActiveTemplate(val),
+})
 </script>

--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -34,9 +34,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import type { Component } from 'vue'
 import { useXmlParser } from '~/composables/useXmlParser'
-import { getCurrentTemplate } from '~/composables/useTemplate'
+import { useTemplate } from '~/composables/useTemplate'
 import type { ParsedData } from '~/composables/useXmlParser'
 
 // Ensure this component only runs on the client side (DOMParser is browser-only)
@@ -68,10 +67,10 @@ const props = withDefaults(defineProps<Props>(), {
 const parsedData = ref<ParsedData | undefined>(undefined)
 const error = ref<string | undefined>(undefined)
 const isLoading = ref(false)
-const templateComponent = ref<Component | undefined>(undefined)
 
 // Get composables
 const { parseXml } = useXmlParser()
+const { currentTemplate: templateComponent, activeTemplate } = useTemplate()
 
 // Computed style for zoom transform
 const containerStyle = computed(() => ({
@@ -84,32 +83,23 @@ const containerStyle = computed(() => ({
  * Handles all parsing errors gracefully with user-friendly messages
  */
 function updatePreview() {
-  // Reset state
   isLoading.value = true
   error.value = undefined
   parsedData.value = undefined
-  templateComponent.value = undefined
 
   try {
-    // Get the current template component
-    templateComponent.value = getCurrentTemplate()
-
-    // Parse XML content
     const result = parseXml(props.xmlContent)
 
     if (result.success && result.data) {
-      // Success: update parsed data
       parsedData.value = result.data
       error.value = undefined
     }
     else {
-      // Parsing failed: show user-friendly error
       error.value = result.error || 'Unknown parsing error occurred'
       parsedData.value = undefined
     }
   }
   catch (err) {
-    // Catch any unexpected errors (e.g., template not found)
     const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred'
     error.value = `Preview error: ${errorMessage}`
     parsedData.value = undefined
@@ -119,9 +109,9 @@ function updatePreview() {
   }
 }
 
-// Watch for changes to xmlContent and re-parse automatically
+// Re-parse when xmlContent changes, and re-render when active template changes
 watch(
-  () => props.xmlContent,
+  [() => props.xmlContent, activeTemplate],
   () => {
     updatePreview()
   },

--- a/composables/useTemplate.ts
+++ b/composables/useTemplate.ts
@@ -1,15 +1,18 @@
 /**
  * Template System Composable
  *
- * Provides template selection and management for document rendering.
- * PoC Implementation: Uses code-level template switching via ACTIVE_TEMPLATE constant.
- * (See DECISIONS.md Decision 4: UI dropdown is post-PoC feature)
+ * Provides reactive template selection and management for document rendering.
+ * Active template is shared across all components via useState and persisted
+ * to localStorage so the selection survives page reloads.
  */
 
+import { onMounted, computed } from 'vue'
 import type { Component } from 'vue'
 import CoverLetterModern from '~/templates/modern/CoverLetterModern.vue'
 import CoverLetterClassic from '~/templates/classic/CoverLetterClassic.vue'
 import CoverLetterMinimal from '~/templates/minimal/CoverLetterMinimal.vue'
+
+const LS_KEY = 'ohmydoc_template'
 
 // Template metadata interface for future extensibility
 export interface TemplateMetadata {
@@ -25,24 +28,6 @@ export interface TemplateRegistry {
     metadata: TemplateMetadata
   }
 }
-
-/**
- * ACTIVE_TEMPLATE Constant
- *
- * Change this constant to switch templates in the PoC.
- * Available options: 'modern', 'classic', 'minimal'
- *
- * Example:
- *   const ACTIVE_TEMPLATE = 'modern'  // Uses Modern template (default)
- *   const ACTIVE_TEMPLATE = 'classic' // Uses Classic template (table-based layout)
- *   const ACTIVE_TEMPLATE = 'minimal' // Uses Minimal template (clean, minimalist style)
- *
- * Template Descriptions:
- * - modern: Professional cover letter with modern styling, semantic HTML (article/header)
- * - classic: Traditional cover letter with table-based layout, uppercase headers
- * - minimal: Clean, minimalist design with simple div structure and generous whitespace
- */
-const ACTIVE_TEMPLATE = 'modern'
 
 /**
  * Template Registry
@@ -78,69 +63,73 @@ const templates: TemplateRegistry = {
 }
 
 /**
- * Get the currently active template component
+ * Composable function to use the reactive template system in Vue components.
  *
- * @returns The Vue component for the active template
- * @throws Error if the active template is not found in the registry
- */
-export function getCurrentTemplate(): Component {
-  const templateEntry = templates[ACTIVE_TEMPLATE]
-
-  if (!templateEntry) {
-    throw new Error(
-      `Template "${ACTIVE_TEMPLATE}" not found. Available templates: ${Object.keys(templates).join(', ')}`
-    )
-  }
-
-  return templateEntry.component
-}
-
-/**
- * Get metadata for the currently active template
+ * Active template state is shared across all component instances via useState.
+ * On mount, the saved localStorage value is restored (client-side only).
  *
- * @returns Template metadata for the active template
- */
-export function getCurrentTemplateMetadata(): TemplateMetadata {
-  const templateEntry = templates[ACTIVE_TEMPLATE]
-
-  if (!templateEntry) {
-    throw new Error(
-      `Template "${ACTIVE_TEMPLATE}" not found. Available templates: ${Object.keys(templates).join(', ')}`
-    )
-  }
-
-  return templateEntry.metadata
-}
-
-/**
- * Get all available template names
- *
- * @returns Array of template names
- */
-export function getAvailableTemplates(): string[] {
-  return Object.keys(templates)
-}
-
-/**
- * Get metadata for all available templates
- *
- * @returns Array of template metadata objects
- */
-export function getAllTemplateMetadata(): TemplateMetadata[] {
-  return Object.values(templates).map(t => t.metadata)
-}
-
-/**
- * Composable function to use template system in Vue components
- *
- * @returns Object with template selection functions
+ * @returns Reactive template state and control functions
  */
 export function useTemplate() {
+  // Shared reactive state — useState ensures all components see the same value
+  const activeTemplate = useState<string>('activeTemplate', () => 'modern')
+
+  // Restore from localStorage after hydration (client-only, runs once per component mount)
+  onMounted(() => {
+    try {
+      const saved = localStorage.getItem(LS_KEY)
+      if (saved && templates[saved]) {
+        activeTemplate.value = saved
+      }
+    }
+    catch {
+      // Ignore storage errors (private browsing, quota exceeded, etc.)
+    }
+  })
+
+  /**
+   * Switch to a different template and persist the choice to localStorage.
+   */
+  function setActiveTemplate(name: string) {
+    if (!templates[name]) {
+      console.warn(`Template "${name}" not found. Available: ${Object.keys(templates).join(', ')}`)
+      return
+    }
+    activeTemplate.value = name
+    try {
+      localStorage.setItem(LS_KEY, name)
+    }
+    catch {
+      // Ignore storage errors
+    }
+  }
+
+  /** Reactive component for the currently active template */
+  const currentTemplate = computed<Component | undefined>(
+    () => templates[activeTemplate.value]?.component,
+  )
+
+  /** Metadata for the currently active template */
+  const currentTemplateMetadata = computed<TemplateMetadata | undefined>(
+    () => templates[activeTemplate.value]?.metadata,
+  )
+
+  /** Names of all registered templates */
+  function getAvailableTemplates(): string[] {
+    return Object.keys(templates)
+  }
+
+  /** Metadata objects for all registered templates */
+  function getAllTemplateMetadata(): TemplateMetadata[] {
+    return Object.values(templates).map(t => t.metadata)
+  }
+
   return {
-    getCurrentTemplate,
-    getCurrentTemplateMetadata,
+    activeTemplate,
+    setActiveTemplate,
+    currentTemplate,
+    currentTemplateMetadata,
     getAvailableTemplates,
     getAllTemplateMetadata,
-    activeTemplate: ACTIVE_TEMPLATE,
   }
 }


### PR DESCRIPTION
## Summary

- Adds a **USelectMenu** dropdown in `AppHeader` listing Modern, Classic, and Minimal templates
- Selecting a template instantly re-renders the preview panel with no page reload
- Chosen template is saved to `localStorage` (`ohmydoc_template`) and restored on reload

## Changes

| File | What changed |
|---|---|
| `composables/useTemplate.ts` | Replaced static `ACTIVE_TEMPLATE` constant with reactive `useState`; added `setActiveTemplate()` with localStorage write; exposed `currentTemplate` computed ref |
| `components/AppHeader.vue` | Added `USelectMenu` bound to `activeTemplate` via `useTemplate()` composable |
| `components/PreviewPanel.vue` | Switched to `useTemplate()` composable; watches `activeTemplate` alongside `xmlContent` so template changes trigger immediate re-render |

## Test plan

- [ ] Open app, verify "Template:" dropdown appears in header with Modern / Classic / Minimal options
- [ ] Select each template and confirm the preview re-renders instantly
- [ ] Reload page and confirm the previously selected template is restored from localStorage
- [ ] Verify the XML editor, export flow, and debug pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)