### PR TITLE
style: visual polish — compact header, transitions, panel spacing

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <UContainer class="py-4 border-b border-gray-200 dark:border-gray-800">
+  <UContainer class="app-header border-b border-gray-200 dark:border-gray-800">
     <div class="flex items-center justify-between">
       <!-- Left action slot for future buttons (Format, Clear, Import - MVP 8) -->
       <div class="flex items-center gap-2">
@@ -8,26 +8,23 @@
 
       <!-- App Title and Tagline -->
       <div class="text-center">
-        <h1 class="text-xl font-bold text-gray-900 dark:text-white">
-          OhMyDoc v2
+        <h1 class="text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
+          OhMyDoc
         </h1>
-        <p class="text-xs text-gray-600 dark:text-gray-400">
-          XML to HTML Transformer
-        </p>
       </div>
 
       <!-- Right: Template switcher + action slot (Export, Zoom - MVPs 7 & 9) -->
       <div class="flex items-center gap-3">
         <!-- Template Switcher Dropdown -->
         <div class="flex items-center gap-2">
-          <label class="text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">Template:</label>
+          <label class="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">Template</label>
           <USelectMenu
             v-model="selectedTemplate"
             :options="templateOptions"
             value-attribute="value"
             option-attribute="label"
-            size="sm"
-            class="w-32"
+            size="xs"
+            class="w-28"
           />
         </div>
 
@@ -36,6 +33,13 @@
     </div>
   </UContainer>
 </template>
+
+<style scoped>
+.app-header {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+</style>
 
 <script setup lang="ts">
 import { computed } from 'vue'

--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -22,7 +22,9 @@
       class="preview-container"
       :style="containerStyle"
     >
-      <component :is="templateComponent" :data="parsedData" />
+      <Transition name="template-fade" mode="out-in">
+        <component :is="templateComponent" :key="activeTemplate" :data="parsedData" />
+      </Transition>
     </div>
 
     <!-- Placeholder State (no data) -->
@@ -125,7 +127,7 @@ watch(
   height: 100%;
   overflow: auto;
   background-color: var(--color-gray-50);
-  padding: 1rem;
+  padding: 1.5rem 1.25rem;
 }
 
 .error-alert {
@@ -146,5 +148,17 @@ watch(
   min-width: 100%;
   /* Ensure zoom transform doesn't clip content */
   padding-bottom: 2rem;
+}
+
+/* Template switch fade transition */
+.template-fade-enter-active,
+.template-fade-leave-active {
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.template-fade-enter-from,
+.template-fade-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -210,7 +210,8 @@ onUnmounted(() => {
   flex-direction: column;
   overflow: hidden;
   background-color: #1e1e1e; /* Dark editor background */
-  border-right: 1px solid var(--color-gray-300);
+  border-right: 1px solid var(--color-gray-200);
+  transition: border-color 0.15s ease;
 }
 
 /**
@@ -222,6 +223,7 @@ onUnmounted(() => {
   flex-direction: column;
   overflow: auto;
   background-color: var(--color-gray-50);
+  transition: background-color 0.15s ease;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Compact AppHeader: reduced to `py-2`, smaller title text (`text-sm`), dropped the tagline line, smaller template dropdown (`xs` size, `w-28`)
- Template-switch fade transition in `PreviewPanel` using Vue `<Transition mode="out-in">` with 180ms opacity + subtle Y-slide
- Panel divider uses lighter `gray-200` border; subtle `transition` on border-color and preview background
- Preview panel padding adjusted to `1.5rem 1.25rem` for better document breathing room
- No debug links existed in navigation — nothing to hide

## Test plan
- [ ] Header looks compact and clean without feeling cramped
- [ ] Switching templates shows a smooth fade-slide transition in the preview
- [ ] Dual-panel divider renders cleanly
- [ ] No visual regressions on welcome screen or dual-panel layout
- [ ] `/debug/*` routes still reachable by direct URL (not removed, just not linked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)