### PR TITLE
feat: add resignation letter document type

### DIFF
--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -38,7 +38,6 @@
 import { ref, computed, watch } from 'vue'
 import { useTemplate } from '~/composables/useTemplate'
 import { useDocumentType } from '~/composables/useDocumentType'
-import type { ParsedData } from '~/composables/useXmlParser'
 
 // Ensure this component only runs on the client side (DOMParser is browser-only)
 defineOptions({
@@ -65,8 +64,8 @@ const props = withDefaults(defineProps<Props>(), {
   zoom: 1,
 })
 
-// Reactive state
-const parsedData = ref<ParsedData | undefined>(undefined)
+// Reactive state — typed as unknown to support multiple document types
+const parsedData = ref<unknown>(undefined)
 const error = ref<string | undefined>(undefined)
 const isLoading = ref(false)
 

--- a/composables/useDocumentType.ts
+++ b/composables/useDocumentType.ts
@@ -13,6 +13,7 @@
 import { computed, onMounted } from 'vue'
 import { parseXml as parseCoverLetterXml, validateXml as validateCoverLetterXml } from '~/composables/useXmlParser'
 import type { ValidationResult, ParseResult } from '~/composables/useXmlParser'
+import { parseResignationXml, validateResignationXml } from '~/composables/useResignationParser'
 
 const LS_KEY = 'ohmydoc_document_type'
 
@@ -56,6 +57,16 @@ const documentTypes: Record<string, DocumentTypeConfig> = {
     templates: ['modern', 'classic', 'minimal'],
     parse: parseCoverLetterXml,
     validate: validateCoverLetterXml,
+  },
+  'resignation-letter': {
+    name: 'resignation-letter',
+    displayName: 'Resignation Letter',
+    description: 'Formal resignation letter to notify an employer',
+    sampleXmlPath: '/samples/resignation-letter.xml',
+    defaultTemplate: 'resignation-professional',
+    templates: ['resignation-professional', 'resignation-brief'],
+    parse: parseResignationXml,
+    validate: validateResignationXml,
   },
 }
 

--- a/composables/useResignationParser.ts
+++ b/composables/useResignationParser.ts
@@ -1,0 +1,173 @@
+/**
+ * Resignation Letter Parser Composable
+ *
+ * Provides XML parsing and validation for resignation letter documents.
+ * Uses the same browser DOMParser approach as useXmlParser.ts.
+ *
+ * XML Schema:
+ * <resignationLetter>
+ *   <sender>
+ *     <name>...</name>
+ *     <position>...</position>
+ *   </sender>
+ *   <date>...</date>
+ *   <recipient>
+ *     <name>...</name>
+ *     <title>...</title>
+ *     <company>...</company>
+ *   </recipient>
+ *   <body>
+ *     <paragraph>...</paragraph>
+ *   </body>
+ *   <signature>
+ *     <name>...</name>
+ *     <position>...</position>
+ *   </signature>
+ * </resignationLetter>
+ */
+
+import type { ValidationResult, ParseResult } from '~/composables/useXmlParser'
+
+// ─── Type definitions ─────────────────────────────────────────────────────────
+
+export interface ResignationSender {
+  name: string
+  position: string
+}
+
+export interface ResignationRecipient {
+  name: string
+  title: string
+  company: string
+}
+
+export interface ResignationSignature {
+  name: string
+  position: string
+}
+
+export interface ResignationParsedData {
+  sender: ResignationSender
+  date: string
+  recipient: ResignationRecipient
+  body: string[]
+  signature: ResignationSignature
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getText(parent: Element | null, selector: string): string {
+  if (!parent) return ''
+  return parent.querySelector(selector)?.textContent?.trim() ?? ''
+}
+
+// ─── Validate ─────────────────────────────────────────────────────────────────
+
+export function validateResignationXml(xmlString: string): ValidationResult {
+  if (!xmlString || xmlString.trim() === '') {
+    return {
+      isValid: false,
+      error: 'XML input is empty. Please provide valid XML content.',
+    }
+  }
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(xmlString, 'text/xml')
+
+  const parserError = doc.querySelector('parsererror')
+  if (parserError) {
+    const errorText = parserError.textContent || 'Unknown XML parsing error'
+
+    if (errorText.includes('unclosed tag') || errorText.includes('Opening and ending tag mismatch')) {
+      return {
+        isValid: false,
+        error: 'XML has unclosed or mismatched tags. Please check that all opening tags have corresponding closing tags.',
+      }
+    }
+    if (errorText.includes('Unexpected end of file') || errorText.includes('premature end of data')) {
+      return {
+        isValid: false,
+        error: 'XML is incomplete. The document appears to end unexpectedly.',
+      }
+    }
+
+    return {
+      isValid: false,
+      error: `XML parsing error: ${errorText}`,
+    }
+  }
+
+  const root = doc.documentElement
+  if (!root || root.tagName !== 'resignationLetter') {
+    return {
+      isValid: false,
+      error: 'Invalid XML structure. Root element must be <resignationLetter>.',
+    }
+  }
+
+  const required = ['sender', 'date', 'recipient', 'body', 'signature']
+  for (const el of required) {
+    if (!root.querySelector(el)) {
+      return {
+        isValid: false,
+        error: `Missing required element: <${el}>. Resignation letters must include sender, date, recipient, body, and signature.`,
+      }
+    }
+  }
+
+  return { isValid: true }
+}
+
+// ─── Parse ────────────────────────────────────────────────────────────────────
+
+export function parseResignationXml(xmlString: string): ParseResult {
+  try {
+    const validation = validateResignationXml(xmlString)
+    if (!validation.isValid) {
+      return { success: false, error: validation.error }
+    }
+
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(xmlString, 'text/xml')
+    const root = doc.documentElement
+
+    const senderEl = root.querySelector('sender')
+    const recipientEl = root.querySelector('recipient')
+    const bodyEl = root.querySelector('body')
+    const signatureEl = root.querySelector('signature')
+
+    const sender: ResignationSender = {
+      name: getText(senderEl, 'name'),
+      position: getText(senderEl, 'position'),
+    }
+
+    const recipient: ResignationRecipient = {
+      name: getText(recipientEl, 'name'),
+      title: getText(recipientEl, 'title'),
+      company: getText(recipientEl, 'company'),
+    }
+
+    const body: string[] = bodyEl
+      ? Array.from(bodyEl.querySelectorAll('paragraph')).map(p => p.textContent?.trim() ?? '').filter(t => t)
+      : []
+
+    const signature: ResignationSignature = {
+      name: getText(signatureEl, 'name'),
+      position: getText(signatureEl, 'position'),
+    }
+
+    const data: ResignationParsedData = {
+      sender,
+      date: root.querySelector('date')?.textContent?.trim() ?? '',
+      recipient,
+      body,
+      signature,
+    }
+
+    return { success: true, data }
+  }
+  catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error occurred during parsing'
+    return { success: false, error: `Failed to parse XML: ${msg}` }
+  }
+}

--- a/composables/useTemplate.ts
+++ b/composables/useTemplate.ts
@@ -11,6 +11,8 @@ import type { Component } from 'vue'
 import CoverLetterModern from '~/templates/modern/CoverLetterModern.vue'
 import CoverLetterClassic from '~/templates/classic/CoverLetterClassic.vue'
 import CoverLetterMinimal from '~/templates/minimal/CoverLetterMinimal.vue'
+import ResignationProfessional from '~/templates/resignation-professional/ResignationProfessional.vue'
+import ResignationBrief from '~/templates/resignation-brief/ResignationBrief.vue'
 
 const LS_KEY = 'ohmydoc_template'
 
@@ -63,6 +65,24 @@ const templates: TemplateRegistry = {
       displayName: 'Minimal',
       description: 'Clean, minimalist cover letter design with simple structure and generous whitespace',
       documentTypes: ['cover-letter'],
+    },
+  },
+  'resignation-professional': {
+    component: ResignationProfessional,
+    metadata: {
+      name: 'resignation-professional',
+      displayName: 'Professional',
+      description: 'Formal letterhead layout with sender top-left, date top-right, and clean typography',
+      documentTypes: ['resignation-letter'],
+    },
+  },
+  'resignation-brief': {
+    component: ResignationBrief,
+    metadata: {
+      name: 'resignation-brief',
+      displayName: 'Brief',
+      description: 'Compact, minimal resignation letter with just the essentials',
+      documentTypes: ['resignation-letter'],
     },
   },
 }

--- a/composables/useXmlParser.ts
+++ b/composables/useXmlParser.ts
@@ -64,7 +64,7 @@ export interface ValidationResult {
 
 export interface ParseResult {
   success: boolean
-  data?: ParsedData
+  data?: unknown
   error?: string
 }
 

--- a/public/samples/resignation-letter.xml
+++ b/public/samples/resignation-letter.xml
@@ -1,0 +1,22 @@
+<resignationLetter>
+    <sender>
+        <name>Jane Doe</name>
+        <position>Marketing Coordinator</position>
+    </sender>
+    <date>March 15, 2026</date>
+    <recipient>
+        <name>John Smith</name>
+        <title>Director of Operations</title>
+        <company>Brightwave Marketing</company>
+    </recipient>
+    <body>
+        <paragraph>I am writing to formally notify you of my resignation from my position as Marketing Coordinator at Brightwave Marketing, effective March 29, 2026. I am providing two weeks notice as required by my employment agreement.</paragraph>
+        <paragraph>During my time at Brightwave Marketing, I have had the privilege of working alongside a talented and dedicated team. I am grateful for the opportunities I have been given to grow professionally, lead meaningful campaigns, and contribute to the company's success.</paragraph>
+        <paragraph>I am committed to ensuring a smooth transition. Over the next two weeks, I will do my best to complete outstanding projects, document ongoing work, and assist in onboarding my replacement if needed. Please let me know how I can best support the team during this period.</paragraph>
+        <paragraph>Thank you for the support and mentorship you have provided throughout my tenure. I hope to stay in touch and wish the company continued success in the years ahead.</paragraph>
+    </body>
+    <signature>
+        <name>Jane Doe</name>
+        <position>Marketing Coordinator</position>
+    </signature>
+</resignationLetter>

--- a/templates/resignation-brief/ResignationBrief.vue
+++ b/templates/resignation-brief/ResignationBrief.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="resignation-brief">
+    <!-- Compact header: name, position, date inline -->
+    <div class="rb-header">
+      <span class="rb-name">{{ data.sender.name }}</span>
+      <span v-if="data.sender.position" class="rb-sep">·</span>
+      <span v-if="data.sender.position" class="rb-position">{{ data.sender.position }}</span>
+      <span v-if="data.date" class="rb-date">{{ data.date }}</span>
+    </div>
+
+    <!-- Recipient line -->
+    <div v-if="data.recipient" class="rb-recipient">
+      <span v-if="data.recipient.name">{{ data.recipient.name }}</span>
+      <template v-if="data.recipient.title">
+        <span class="rb-sep">·</span>
+        <span>{{ data.recipient.title }}</span>
+      </template>
+      <template v-if="data.recipient.company">
+        <span class="rb-sep">·</span>
+        <span>{{ data.recipient.company }}</span>
+      </template>
+    </div>
+
+    <!-- Body paragraphs -->
+    <div v-if="data.body && data.body.length > 0" class="rb-body">
+      <p v-for="(paragraph, index) in data.body" :key="index" class="rb-paragraph">
+        {{ paragraph }}
+      </p>
+    </div>
+
+    <!-- Signature -->
+    <div v-if="data.signature" class="rb-signature">
+      {{ data.signature.name }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ResignationParsedData } from '~/composables/useResignationParser'
+import './styles.css'
+
+/**
+ * Brief Resignation Letter Template
+ *
+ * Compact, no-frills layout. Single-line header with name and date,
+ * recipient on one line, then body paragraphs and a minimal signature.
+ * Uses only scoped CSS — no @nuxt/ui components — so it is exportable as
+ * standalone HTML.
+ */
+
+interface Props {
+  data: ResignationParsedData
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+/**
+ * CSS is imported as a module in the <script> section above.
+ * This empty scoped block applies Vue's data-v-* scoping to all elements.
+ * See CLAUDE.md "Template System" section for rationale.
+ */
+</style>

--- a/templates/resignation-brief/styles.css
+++ b/templates/resignation-brief/styles.css
@@ -1,0 +1,120 @@
+/**
+ * Brief Resignation Letter Template Styles
+ *
+ * Compact, minimal design — just the essentials.
+ * Single-line header, one-line recipient, plain paragraphs, short signature.
+ *
+ * Color palette: --ink: #111, --muted: #555  (project design system)
+ * Typography:    --font-body: ui-serif (document body), --font-ui: ui-sans-serif (header/meta)
+ */
+
+/* ── Design System ───────────────────────────────────────────────────── */
+:root {
+  --rb-font-body: ui-serif, Georgia, "Times New Roman", Times, serif;
+  --rb-font-ui:   ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --rb-ink:       #111;
+  --rb-muted:     #666;
+  --rb-max-width: 640px;
+  --rb-line:      1.6;
+}
+
+/* ── Document Container ──────────────────────────────────────────────── */
+.resignation-brief {
+  margin: 0 auto;
+  max-width: var(--rb-max-width);
+  background: #fff;
+  color: var(--rb-ink);
+  font: 15px/var(--rb-line) var(--rb-font-body);
+  padding: 2rem 1rem;
+}
+
+/* ── Header Row ─────────────────────────────────────────────────────── */
+.rb-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: var(--rb-font-ui);
+  font-size: 0.85rem;
+  color: var(--rb-muted);
+  margin-bottom: 0.35rem;
+}
+
+.rb-name {
+  font-weight: 600;
+  color: var(--rb-ink);
+  font-size: 1rem;
+}
+
+.rb-position {
+  color: var(--rb-muted);
+}
+
+/* Date pushed to the right */
+.rb-date {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.rb-sep {
+  color: var(--rb-muted);
+  opacity: 0.5;
+  user-select: none;
+}
+
+/* ── Recipient Line ──────────────────────────────────────────────────── */
+.rb-recipient {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-family: var(--rb-font-ui);
+  font-size: 0.82rem;
+  color: var(--rb-muted);
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+/* ── Body Paragraphs ────────────────────────────────────────────────── */
+.rb-body {
+  margin-bottom: 1.75rem;
+}
+
+.rb-paragraph {
+  margin: 0 0 0.85rem 0;
+}
+
+.rb-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Signature ──────────────────────────────────────────────────────── */
+.rb-signature {
+  margin-top: 1.75rem;
+  font-family: var(--rb-font-ui);
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--rb-ink);
+}
+
+/* ── Print ──────────────────────────────────────────────────────────── */
+@media print {
+  .resignation-brief {
+    padding: 0;
+    max-width: none;
+    margin: 0 2cm;
+  }
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────── */
+@media screen and (max-width: 600px) {
+  .resignation-brief {
+    padding: 1rem 0.75rem;
+  }
+
+  .rb-date {
+    margin-left: 0;
+    width: 100%;
+  }
+}

--- a/templates/resignation-professional/ResignationProfessional.vue
+++ b/templates/resignation-professional/ResignationProfessional.vue
@@ -1,0 +1,62 @@
+<template>
+  <article class="resignation-professional">
+    <!-- Letterhead: sender info top-left, date top-right -->
+    <header class="rp-header">
+      <div class="rp-sender">
+        <h1 class="rp-sender-name">{{ data.sender.name }}</h1>
+        <p v-if="data.sender.position" class="rp-sender-position">{{ data.sender.position }}</p>
+      </div>
+      <div v-if="data.date" class="rp-date">{{ data.date }}</div>
+    </header>
+
+    <hr class="rp-rule">
+
+    <!-- Recipient block -->
+    <div v-if="data.recipient" class="rp-recipient">
+      <p v-if="data.recipient.name" class="rp-recipient-name">{{ data.recipient.name }}</p>
+      <p v-if="data.recipient.title" class="rp-recipient-title">{{ data.recipient.title }}</p>
+      <p v-if="data.recipient.company" class="rp-recipient-company">{{ data.recipient.company }}</p>
+    </div>
+
+    <!-- Body paragraphs -->
+    <main v-if="data.body && data.body.length > 0" class="rp-body">
+      <p v-for="(paragraph, index) in data.body" :key="index" class="rp-paragraph">
+        {{ paragraph }}
+      </p>
+    </main>
+
+    <!-- Signature block -->
+    <footer v-if="data.signature" class="rp-signature-block">
+      <p class="rp-signature-name">{{ data.signature.name }}</p>
+      <p v-if="data.signature.position" class="rp-signature-position">{{ data.signature.position }}</p>
+    </footer>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { ResignationParsedData } from '~/composables/useResignationParser'
+import './styles.css'
+
+/**
+ * Professional Resignation Letter Template
+ *
+ * Formal letterhead layout: sender top-left, date top-right, ruled divider,
+ * then recipient block, body paragraphs, and signature.
+ * Uses only scoped CSS — no @nuxt/ui components — so it is exportable as
+ * standalone HTML.
+ */
+
+interface Props {
+  data: ResignationParsedData
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+/**
+ * CSS is imported as a module in the <script> section above.
+ * This empty scoped block applies Vue's data-v-* scoping to all elements.
+ * See CLAUDE.md "Template System" section for rationale.
+ */
+</style>

--- a/templates/resignation-professional/styles.css
+++ b/templates/resignation-professional/styles.css
@@ -1,0 +1,168 @@
+/**
+ * Professional Resignation Letter Template Styles
+ *
+ * Formal letterhead design: sender top-left, date top-right, ruled divider.
+ * Inherits the project design system palette from PRD.md §4.2.
+ *
+ * Color palette: --ink: #111, --muted: #555, --accent: #0f6fec
+ * Typography:    --font-body: ui-serif, --font-ui: ui-sans-serif
+ *
+ * Scoped via Vue's data-v-* attributes — safe to use generic selectors.
+ */
+
+/* ── Design System ───────────────────────────────────────────────────── */
+:root {
+  --rp-font-body: ui-serif, Georgia, "Times New Roman", Times, serif;
+  --rp-font-ui:   ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --rp-ink:       #111;
+  --rp-muted:     #555;
+  --rp-rule:      #d4d4d4;
+  --rp-max-width: 720px;
+  --rp-line:      1.65;
+}
+
+/* ── Document Container ──────────────────────────────────────────────── */
+.resignation-professional {
+  margin: 0 auto;
+  max-width: var(--rp-max-width);
+  background: #fff;
+  color: var(--rp-ink);
+  font: 16px/var(--rp-line) var(--rp-font-body);
+  padding: 2.5rem 1.25rem;
+}
+
+/* ── Header (sender left / date right) ─────────────────────────────── */
+.rp-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+}
+
+.rp-sender {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.rp-sender-name {
+  font-family: var(--rp-font-ui);
+  font-size: clamp(1.3rem, 1.8vw + 0.8rem, 1.75rem);
+  font-weight: 600;
+  line-height: 1.2;
+  margin: 0;
+  color: var(--rp-ink);
+}
+
+.rp-sender-position {
+  margin: 0;
+  font-family: var(--rp-font-ui);
+  font-size: 0.9rem;
+  color: var(--rp-muted);
+  letter-spacing: 0.01em;
+}
+
+.rp-date {
+  font-family: var(--rp-font-ui);
+  font-size: 0.9rem;
+  color: var(--rp-muted);
+  white-space: nowrap;
+  padding-top: 0.25rem;
+}
+
+/* ── Divider ────────────────────────────────────────────────────────── */
+.rp-rule {
+  border: none;
+  border-top: 1px solid var(--rp-rule);
+  margin: 0 0 1.5rem 0;
+}
+
+/* ── Recipient Block ────────────────────────────────────────────────── */
+.rp-recipient {
+  margin-bottom: 1.75rem;
+}
+
+.rp-recipient p {
+  margin: 0 0 0.15rem 0;
+  line-height: 1.5;
+}
+
+.rp-recipient-name {
+  font-weight: 600;
+  color: var(--rp-ink);
+}
+
+.rp-recipient-title {
+  color: var(--rp-muted);
+  font-size: 0.95rem;
+}
+
+.rp-recipient-company {
+  color: var(--rp-ink);
+  font-family: var(--rp-font-ui);
+  font-size: 0.95rem;
+}
+
+/* ── Body Paragraphs ────────────────────────────────────────────────── */
+.rp-body {
+  margin-bottom: 2rem;
+}
+
+.rp-paragraph {
+  margin: 0 0 1rem 0;
+  text-align: justify;
+  hyphens: auto;
+}
+
+.rp-paragraph:last-child {
+  margin-bottom: 0;
+}
+
+/* ── Signature Block ────────────────────────────────────────────────── */
+.rp-signature-block {
+  margin-top: 2.5rem;
+}
+
+.rp-signature-block p {
+  margin: 0 0 0.15rem 0;
+}
+
+.rp-signature-name {
+  font-weight: 600;
+  color: var(--rp-ink);
+}
+
+.rp-signature-position {
+  font-family: var(--rp-font-ui);
+  font-size: 0.9rem;
+  color: var(--rp-muted);
+}
+
+/* ── Print ──────────────────────────────────────────────────────────── */
+@media print {
+  .resignation-professional {
+    padding: 0;
+    max-width: none;
+    margin: 0 2cm;
+  }
+}
+
+/* ── Responsive ─────────────────────────────────────────────────────── */
+@media screen and (max-width: 768px) {
+  .resignation-professional {
+    padding: 1.25rem 0.75rem;
+  }
+
+  .rp-header {
+    flex-direction: column-reverse;
+    gap: 0.5rem;
+  }
+
+  .rp-sender-name {
+    font-size: 1.35rem;
+  }
+
+  .rp-paragraph {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds **Resignation Letter** as the second document type using the `useDocumentType` abstraction
- Two new templates: **Professional** (letterhead layout, date right-aligned) and **Brief** (compact, minimal)
- Widens `ParseResult.data` to `unknown` so the parse result interface is not tied to cover-letter's `ParsedData` type

## Changes
- `composables/useResignationParser.ts` — new parser/validator with `ResignationParsedData` types
- `public/samples/resignation-letter.xml` — sample resignation letter XML
- `templates/resignation-professional/` — formal letterhead template
- `templates/resignation-brief/` — compact minimal template
- `composables/useDocumentType.ts` — registers `resignation-letter` doc type
- `composables/useTemplate.ts` — registers both new templates with `documentTypes: ['resignation-letter']`
- `composables/useXmlParser.ts` — `ParseResult.data` widened from `ParsedData` to `unknown`
- `components/PreviewPanel.vue` — `parsedData` ref updated to `unknown` to match

## Test plan
- [ ] Select "Resignation Letter" from the Type dropdown in the header
- [ ] Confirm sample XML loads and both Professional and Brief templates render correctly
- [ ] Switch back to Cover Letter — existing templates still work
- [ ] Verify template dropdown only shows templates relevant to the active doc type

🤖 Generated with [Claude Code](https://claude.com/claude-code)