### PR TITLE
feat: add Executive and Creative cover letter templates

### DIFF
--- a/composables/useTemplate.ts
+++ b/composables/useTemplate.ts
@@ -11,6 +11,8 @@ import type { Component } from 'vue'
 import CoverLetterModern from '~/templates/modern/CoverLetterModern.vue'
 import CoverLetterClassic from '~/templates/classic/CoverLetterClassic.vue'
 import CoverLetterMinimal from '~/templates/minimal/CoverLetterMinimal.vue'
+import CoverLetterExecutive from '~/templates/executive/CoverLetterExecutive.vue'
+import CoverLetterCreative from '~/templates/creative/CoverLetterCreative.vue'
 import ResignationProfessional from '~/templates/resignation-professional/ResignationProfessional.vue'
 import ResignationBrief from '~/templates/resignation-brief/ResignationBrief.vue'
 
@@ -64,6 +66,24 @@ const templates: TemplateRegistry = {
       name: 'minimal',
       displayName: 'Minimal',
       description: 'Clean, minimalist cover letter design with simple structure and generous whitespace',
+      documentTypes: ['cover-letter'],
+    },
+  },
+  executive: {
+    component: CoverLetterExecutive,
+    metadata: {
+      name: 'executive',
+      displayName: 'Executive',
+      description: 'Bold, confident serif template with navy accent, large name treatment, and horizontal rule dividers',
+      documentTypes: ['cover-letter'],
+    },
+  },
+  creative: {
+    component: CoverLetterCreative,
+    metadata: {
+      name: 'creative',
+      displayName: 'Creative',
+      description: 'Two-column layout with vibrant accent sidebar — designed for designers, creatives, and marketers',
       documentTypes: ['cover-letter'],
     },
   },

--- a/templates/creative/CoverLetterCreative.vue
+++ b/templates/creative/CoverLetterCreative.vue
@@ -1,0 +1,90 @@
+<template>
+  <div class="application-document">
+    <!-- Sidebar: name + contact -->
+    <aside class="sidebar">
+      <h1 class="applicant-name">{{ data.applicant.name }}</h1>
+
+      <div class="sidebar-divider" />
+
+      <address v-if="data.applicant.address" class="applicant-address">
+        {{ data.applicant.address.street }}<br>
+        {{ data.applicant.address.city }}, {{ data.applicant.address.state }}<br>
+        {{ data.applicant.address.zipCode }}
+      </address>
+
+      <div v-if="data.applicant.contactInformation" class="contact-information">
+        <span v-if="data.applicant.contactInformation.phone" class="contact-item phone">
+          {{ data.applicant.contactInformation.phone }}
+        </span>
+        <a
+          v-if="data.applicant.contactInformation.email"
+          :href="`mailto:${data.applicant.contactInformation.email}`"
+          class="contact-item email"
+        >
+          {{ data.applicant.contactInformation.email }}
+        </a>
+      </div>
+    </aside>
+
+    <!-- Main content: date, recipient, letter -->
+    <main class="main-content">
+      <div v-if="data.date" class="document-date">{{ data.date }}</div>
+
+      <div v-if="data.recipient" class="recipient">
+        <p v-if="data.recipient.position" class="recipient-position">{{ data.recipient.position }}</p>
+        <p v-if="data.recipient.company" class="recipient-company">{{ data.recipient.company }}</p>
+        <address v-if="data.recipient.address" class="recipient-address">
+          {{ data.recipient.address.street }}<br>
+          {{ data.recipient.address.city }}, {{ data.recipient.address.state }} {{ data.recipient.address.zipCode }}
+        </address>
+      </div>
+
+      <div v-if="data.letter" class="letter">
+        <p v-if="data.letter.salutation" class="salutation">{{ data.letter.salutation }}</p>
+        <p v-if="data.letter.introduction" class="introduction">{{ data.letter.introduction }}</p>
+
+        <div
+          v-if="data.letter.experienceSection && data.letter.experienceSection.length > 0"
+          class="experience-section"
+        >
+          <div
+            v-for="(experience, expIndex) in data.letter.experienceSection"
+            :key="expIndex"
+            class="experience"
+          >
+            <p v-if="experience.employer" class="experience-employer">
+              {{ experience.employer }}
+            </p>
+            <ul v-if="experience.achievements && experience.achievements.length > 0" class="achievements">
+              <li
+                v-for="(achievement, achIndex) in experience.achievements"
+                :key="achIndex"
+                class="achievement"
+              >
+                {{ achievement.text }}
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <p v-if="data.letter.motivation" class="motivation">{{ data.letter.motivation }}</p>
+        <p v-if="data.letter.closing" class="closing">{{ data.letter.closing }}</p>
+        <p v-if="data.letter.signature" class="signature">{{ data.letter.signature }}</p>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ParsedData } from '~/composables/useXmlParser'
+import './styles.css'
+
+interface Props {
+  data: ParsedData
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+</style>

--- a/templates/creative/styles.css
+++ b/templates/creative/styles.css
@@ -1,0 +1,254 @@
+/**
+ * Creative Template Styles
+ *
+ * Bold, visually distinctive cover letter for designers, creatives, and marketers.
+ * Two-column layout: vibrant accent sidebar (left) + clean white content area (right).
+ * Sans-serif throughout for a modern, punchy feel.
+ */
+
+:root {
+  --cr-font: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --cr-max-width: 780px;
+  --cr-sidebar-width: 210px;
+  --cr-sidebar-bg: #5e60ce;
+  --cr-sidebar-text: #fff;
+  --cr-sidebar-muted: rgba(255, 255, 255, 0.72);
+  --cr-accent: #48bfe3;
+  --cr-ink: #1a1a2e;
+  --cr-muted: #555570;
+  --cr-line: 1.65;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+/* ── Two-column layout ───────────────────────────────────── */
+
+.application-document {
+  display: grid;
+  grid-template-columns: var(--cr-sidebar-width) 1fr;
+  max-width: var(--cr-max-width);
+  min-height: 900px;
+  margin: 0 auto;
+  background: #fff;
+  font-family: var(--cr-font);
+  color: var(--cr-ink);
+  font-size: 15px;
+  line-height: var(--cr-line);
+}
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+
+.sidebar {
+  background: var(--cr-sidebar-bg);
+  color: var(--cr-sidebar-text);
+  padding: 2.5rem 1.25rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+
+.applicant-name {
+  font-size: 1.45rem;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+  color: #fff;
+  margin: 0 0 1.25rem 0;
+  word-break: break-word;
+}
+
+.sidebar-divider {
+  width: 2.5rem;
+  height: 3px;
+  background: var(--cr-accent);
+  border-radius: 2px;
+  margin-bottom: 1.25rem;
+}
+
+.applicant-address {
+  font-style: normal;
+  font-size: 0.82rem;
+  color: var(--cr-sidebar-muted);
+  line-height: 1.6;
+  margin: 0 0 1.25rem 0;
+}
+
+.contact-information {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin-top: auto;
+  padding-top: 1rem;
+}
+
+.contact-item {
+  font-size: 0.78rem;
+  color: var(--cr-sidebar-muted);
+  word-break: break-all;
+  text-decoration: none;
+}
+
+.contact-item.email {
+  color: var(--cr-accent);
+  text-underline-offset: 2px;
+}
+
+.contact-item.email:hover {
+  text-decoration: underline;
+}
+
+/* ── Main content area ───────────────────────────────────── */
+
+.main-content {
+  padding: 2.5rem 2rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* ── Date ────────────────────────────────────────────────── */
+
+.document-date {
+  font-size: 0.85rem;
+  color: var(--cr-muted);
+  text-align: right;
+}
+
+/* ── Recipient ───────────────────────────────────────────── */
+
+.recipient {
+  border-left: 3px solid var(--cr-sidebar-bg);
+  padding-left: 0.85rem;
+}
+
+.recipient-position {
+  margin: 0 0 0.1rem 0;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--cr-ink);
+}
+
+.recipient-company {
+  margin: 0 0 0.15rem 0;
+  font-size: 0.9rem;
+  color: var(--cr-ink);
+}
+
+.recipient-address {
+  font-style: normal;
+  font-size: 0.82rem;
+  color: var(--cr-muted);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Letter body ─────────────────────────────────────────── */
+
+.letter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.letter > p {
+  margin: 0;
+  line-height: var(--cr-line);
+}
+
+.salutation {
+  font-weight: 600;
+}
+
+.experience-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.experience-employer {
+  margin: 0 0 0.25rem 0;
+  font-weight: 700;
+  color: var(--cr-sidebar-bg);
+  font-size: 0.95rem;
+}
+
+.achievements {
+  margin: 0 0 0 1.25rem;
+  padding: 0;
+  list-style-type: none;
+}
+
+.achievement {
+  position: relative;
+  padding-left: 1rem;
+  margin: 0.2rem 0;
+  line-height: var(--cr-line);
+  color: var(--cr-ink);
+}
+
+.achievement::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  width: 5px;
+  height: 5px;
+  background: var(--cr-accent);
+  border-radius: 50%;
+}
+
+.signature {
+  font-weight: 700;
+  color: var(--cr-sidebar-bg);
+  margin-top: 1.5rem;
+}
+
+/* ── Print ───────────────────────────────────────────────── */
+
+@media print {
+  .application-document {
+    max-width: none;
+  }
+
+  .sidebar {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .contact-item.email {
+    text-decoration: none;
+  }
+}
+
+/* ── Responsive: stack on mobile ────────────────────────── */
+
+@media screen and (max-width: 640px) {
+  .application-document {
+    grid-template-columns: 1fr;
+    min-height: unset;
+  }
+
+  .sidebar {
+    padding: 1.5rem 1.25rem;
+  }
+
+  .applicant-name {
+    font-size: 1.3rem;
+  }
+
+  .contact-information {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding-top: 0.75rem;
+    margin-top: 0.75rem;
+  }
+
+  .main-content {
+    padding: 1.5rem 1.25rem;
+  }
+}

--- a/templates/executive/CoverLetterExecutive.vue
+++ b/templates/executive/CoverLetterExecutive.vue
@@ -1,0 +1,98 @@
+<template>
+  <article class="application-document">
+    <!-- Applicant Header -->
+    <header class="application-header">
+      <h1 class="applicant-name">{{ data.applicant.name }}</h1>
+
+      <div v-if="data.applicant.address || data.applicant.contactInformation" class="header-meta">
+        <address v-if="data.applicant.address" class="applicant-address">
+          {{ data.applicant.address.street }},
+          {{ data.applicant.address.city }}, {{ data.applicant.address.state }} {{ data.applicant.address.zipCode }}
+        </address>
+
+        <div v-if="data.applicant.contactInformation" class="contact-information">
+          <span v-if="data.applicant.contactInformation.phone" class="phone">
+            {{ data.applicant.contactInformation.phone }}
+          </span>
+          <span
+            v-if="data.applicant.contactInformation.phone && data.applicant.contactInformation.email"
+            class="separator"
+          >&nbsp;&middot;&nbsp;</span>
+          <a
+            v-if="data.applicant.contactInformation.email"
+            :href="`mailto:${data.applicant.contactInformation.email}`"
+            class="email"
+          >
+            {{ data.applicant.contactInformation.email }}
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <hr class="rule">
+
+    <!-- Date + Recipient -->
+    <div class="pre-letter">
+      <div v-if="data.date" class="document-date">{{ data.date }}</div>
+
+      <div v-if="data.recipient" class="recipient">
+        <p v-if="data.recipient.position" class="recipient-position">{{ data.recipient.position }}</p>
+        <p v-if="data.recipient.company" class="recipient-company">{{ data.recipient.company }}</p>
+        <address v-if="data.recipient.address" class="recipient-address">
+          {{ data.recipient.address.street }}<br>
+          {{ data.recipient.address.city }}, {{ data.recipient.address.state }} {{ data.recipient.address.zipCode }}
+        </address>
+      </div>
+    </div>
+
+    <hr class="rule">
+
+    <!-- Letter Body -->
+    <main v-if="data.letter" class="letter">
+      <p v-if="data.letter.salutation" class="salutation">{{ data.letter.salutation }}</p>
+      <p v-if="data.letter.introduction" class="introduction">{{ data.letter.introduction }}</p>
+
+      <div
+        v-if="data.letter.experienceSection && data.letter.experienceSection.length > 0"
+        class="experience-section"
+      >
+        <div
+          v-for="(experience, expIndex) in data.letter.experienceSection"
+          :key="expIndex"
+          class="experience"
+        >
+          <p v-if="experience.employer" class="experience-employer">
+            <strong>{{ experience.employer }}</strong>
+          </p>
+          <ul v-if="experience.achievements && experience.achievements.length > 0" class="achievements">
+            <li
+              v-for="(achievement, achIndex) in experience.achievements"
+              :key="achIndex"
+              class="achievement"
+            >
+              {{ achievement.text }}
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <p v-if="data.letter.motivation" class="motivation">{{ data.letter.motivation }}</p>
+      <p v-if="data.letter.closing" class="closing">{{ data.letter.closing }}</p>
+      <p v-if="data.letter.signature" class="signature">{{ data.letter.signature }}</p>
+    </main>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { ParsedData } from '~/composables/useXmlParser'
+import './styles.css'
+
+interface Props {
+  data: ParsedData
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+</style>

--- a/templates/executive/styles.css
+++ b/templates/executive/styles.css
@@ -1,0 +1,222 @@
+/**
+ * Executive Template Styles
+ *
+ * Bold, confident, professional cover letter template.
+ * Serif typography with a navy accent color, strong name treatment,
+ * and clean horizontal rules as section dividers.
+ */
+
+:root {
+  --exec-font-body: Georgia, "Times New Roman", Times, serif;
+  --exec-font-ui: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  --exec-max-width: 720px;
+  --exec-ink: #0d0d0d;
+  --exec-muted: #4a4a4a;
+  --exec-accent: #1a3a5c;
+  --exec-rule: #1a3a5c;
+  --exec-gap: 1rem;
+  --exec-gap-lg: 1.5rem;
+  --exec-line: 1.65;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.application-document {
+  margin: 0 auto;
+  max-width: var(--exec-max-width);
+  background: #fff;
+  color: var(--exec-ink);
+  font: 16px/var(--exec-line) var(--exec-font-body);
+  padding: 2.5rem 1.5rem;
+}
+
+/* ── Header ─────────────────────────────────────────────── */
+
+.application-header {
+  margin-bottom: 1.25rem;
+}
+
+.applicant-name {
+  font-family: var(--exec-font-body);
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--exec-accent);
+  margin: 0 0 0.6rem 0;
+  line-height: 1.1;
+}
+
+.header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 1rem;
+  font-family: var(--exec-font-ui);
+  font-size: 0.88rem;
+  color: var(--exec-muted);
+}
+
+.applicant-address {
+  font-style: normal;
+  margin: 0;
+}
+
+.contact-information {
+  margin: 0;
+}
+
+.contact-information .separator {
+  color: var(--exec-muted);
+}
+
+.contact-information .email {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted currentColor;
+}
+
+.contact-information .email:hover {
+  color: var(--exec-accent);
+}
+
+/* ── Horizontal Rule Dividers ────────────────────────────── */
+
+.rule {
+  border: none;
+  border-top: 1.5px solid var(--exec-rule);
+  margin: 1.25rem 0;
+}
+
+/* ── Date & Recipient ─────────────────────────────────────── */
+
+.pre-letter {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.document-date {
+  font-family: var(--exec-font-ui);
+  font-size: 0.9rem;
+  color: var(--exec-muted);
+  text-align: right;
+}
+
+.recipient {
+  margin-top: 0.25rem;
+}
+
+.recipient-position {
+  margin: 0 0 0.1rem 0;
+  font-weight: 700;
+  color: var(--exec-ink);
+}
+
+.recipient-company {
+  margin: 0 0 0.2rem 0;
+  font-family: var(--exec-font-ui);
+  font-size: 0.95rem;
+  color: var(--exec-ink);
+}
+
+.recipient-address {
+  font-style: normal;
+  color: var(--exec-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Letter Body ─────────────────────────────────────────── */
+
+.letter {
+  margin-top: 0.25rem;
+}
+
+.letter > p {
+  margin: 0 0 1.1rem 0;
+  line-height: var(--exec-line);
+}
+
+.salutation {
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.experience-section {
+  margin: 1rem 0;
+}
+
+.experience {
+  margin-bottom: 1rem;
+}
+
+.experience-employer {
+  margin: 0 0 0.3rem 0;
+}
+
+.experience-employer strong {
+  font-weight: 700;
+  color: var(--exec-accent);
+  font-style: italic;
+}
+
+.achievements {
+  margin: 0.25rem 0 0.75rem 1.5rem;
+  padding: 0;
+  list-style-type: square;
+}
+
+.achievement {
+  margin: 0.25rem 0;
+  line-height: var(--exec-line);
+  color: var(--exec-ink);
+}
+
+.signature {
+  margin-top: 2.75rem;
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--exec-accent);
+  letter-spacing: 0.02em;
+}
+
+/* ── Print ───────────────────────────────────────────────── */
+
+@media print {
+  .application-document {
+    padding: 0;
+    max-width: none;
+    margin: 0 2cm;
+  }
+
+  .contact-information .email {
+    color: inherit;
+    border-bottom: none;
+  }
+}
+
+/* ── Responsive ──────────────────────────────────────────── */
+
+@media screen and (max-width: 768px) {
+  .application-document {
+    padding: 1.5rem 1rem;
+  }
+
+  .applicant-name {
+    font-size: 1.8rem;
+  }
+
+  .header-meta {
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .document-date {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary

- **Executive template** — bold serif (Georgia), navy accent (#1a3a5c), large uppercase name, horizontal rule dividers; targets senior/executive job seekers who need a confident, authoritative look
- **Creative template** — two-column grid with vibrant purple sidebar (#5e60ce) and clean white content area; sans-serif throughout with accent-coloured circular bullets; targets designers, creatives, and marketers
- Both registered in `composables/useTemplate.ts` with `documentTypes: ['cover-letter']` and appear in the template switcher dropdown
- Resignation letter templates already existed (professional + brief), no changes needed

## Test plan

- [ ] Start dev server (`npm run dev`) and open the app
- [ ] Open the template switcher dropdown — confirm **Executive** and **Creative** appear alongside Modern, Classic, Minimal
- [ ] Switch to Executive: verify large navy uppercase name, horizontal rules, serif body text
- [ ] Switch to Creative: verify two-column sidebar layout, purple accent sidebar, sans-serif content
- [ ] Load sample XML and confirm all fields render correctly in both templates
- [ ] Resize viewport to ≤640px and verify Creative collapses to single column; Executive stacks header-meta
- [ ] Print preview both templates (Cmd+P / Ctrl+P) to confirm sidebar background prints and no layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)