### PR TITLE
feat: polish PDF export via window.print()

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -4,3 +4,17 @@
     <NuxtPage />
   </div>
 </template>
+
+<style>
+/**
+ * Global print styles
+ *
+ * @page sets physical page margins and paper size for all print targets.
+ * Template-level styles (margin: 0, max-width: none) work within this area.
+ * 2cm page margin on all sides; templates reset their own CSS margin to 0.
+ */
+@page {
+  size: A4;
+  margin: 2cm;
+}
+</style>

--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -156,6 +156,23 @@ watch(
   padding-bottom: 2rem;
 }
 
+/* Print: reveal full document without scroll clipping or zoom transform */
+@media print {
+  .preview-panel {
+    overflow: visible;
+    height: auto;
+    background: transparent;
+    padding: 0;
+  }
+
+  .preview-container {
+    /* Cancel any active zoom transform so content prints at 100% */
+    transform: none !important;
+    width: 100%;
+    padding-bottom: 0;
+  }
+}
+
 /* Template switch fade transition */
 .template-fade-enter-active,
 .template-fade-leave-active {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,9 +7,16 @@
         <!-- Empty slot - will be populated in MVP 8 -->
       </template>
 
-      <!-- Right action slot reserved for Export and Zoom buttons (MVPs 7 & 9) -->
+      <!-- Right action slot: Export PDF button -->
       <template #right-actions>
-        <!-- Empty slot - will be populated in MVPs 7 & 9 -->
+        <UButton
+          size="xs"
+          variant="outline"
+          icon="i-heroicons-printer"
+          @click="handlePrint"
+        >
+          Export PDF
+        </UButton>
       </template>
     </AppHeader>
 
@@ -82,6 +89,10 @@ import { useDocumentType } from '~/composables/useDocumentType'
  */
 
 const LS_KEY = 'ohmydoc_xml_content'
+
+function handlePrint() {
+  window.print()
+}
 
 const { activeDocumentType, currentDocumentType } = useDocumentType()
 
@@ -240,6 +251,49 @@ onUnmounted(() => {
   overflow: auto;
   background-color: var(--color-gray-50);
   transition: background-color 0.15s ease;
+}
+
+/**
+ * Print: hide all editor chrome, show only the preview document
+ *
+ * - Hide header (dropdowns, buttons, title)
+ * - Hide the XML editor panel
+ * - Collapse the dual-panel grid to a single column
+ * - Let the preview fill the full printable area
+ * - @page margin (in app.vue) provides the physical page margins
+ */
+@media print {
+  .app-container {
+    display: block;
+    height: auto;
+    overflow: visible;
+  }
+
+  /* Hide entire app header (title, type/template dropdowns, export button) */
+  .app-header {
+    display: none;
+  }
+
+  /* Hide the XML editor */
+  .editor-panel {
+    display: none;
+  }
+
+  /* Collapse the two-column grid; let preview fill the page */
+  .dual-panel-layout {
+    display: block;
+    min-width: unset;
+  }
+
+  /* Strip the preview wrapper background so only the document shows */
+  .preview-panel {
+    background: transparent;
+  }
+
+  /* Hide the welcome screen if visible */
+  .welcome-screen {
+    display: none;
+  }
 }
 
 /**

--- a/templates/classic/styles.css
+++ b/templates/classic/styles.css
@@ -221,11 +221,34 @@ td {
   .classic-document {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
   }
 
   .header-table {
     border-bottom: 2px solid #000;
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Avoid splitting experience blocks across pages */
+  .experience-block,
+  .recipient-section {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .experience-employer {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines */
+  .introduction,
+  .motivation,
+  .closing {
+    orphans: 3;
+    widows: 3;
   }
 
   .contact-block .email {

--- a/templates/creative/styles.css
+++ b/templates/creative/styles.css
@@ -212,11 +212,43 @@
 @media print {
   .application-document {
     max-width: none;
+    /* @page in app.vue provides 2cm physical margins; no extra CSS margin needed */
+    margin: 0;
+    /* Ensure two-column grid is preserved in print */
+    display: grid;
+    grid-template-columns: var(--cr-sidebar-width) 1fr;
+    /* Remove screen min-height; let content determine height */
+    min-height: unset;
   }
 
+  /* Force sidebar background colour to print (browsers suppress backgrounds by default) */
   .sidebar {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
+  }
+
+  /* Prevent sidebar from breaking across pages */
+  .sidebar,
+  .main-content {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Avoid splitting experience blocks */
+  .experience-section > * {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .experience-employer {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines */
+  .letter > p {
+    orphans: 3;
+    widows: 3;
   }
 
   .contact-item.email {

--- a/templates/executive/styles.css
+++ b/templates/executive/styles.css
@@ -191,7 +191,35 @@
   .application-document {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
+  }
+
+  /* Avoid splitting key sections across pages */
+  .application-header,
+  .pre-letter,
+  .recipient,
+  .experience,
+  .signature {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .experience-employer {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Keep rule dividers attached to what follows */
+  .rule {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines */
+  .letter > p {
+    orphans: 3;
+    widows: 3;
   }
 
   .contact-information .email {

--- a/templates/minimal/styles.css
+++ b/templates/minimal/styles.css
@@ -158,7 +158,28 @@ li::before {
   .minimal-document {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
+  }
+
+  /* Avoid splitting key blocks across pages */
+  .applicant-section,
+  .recipient-section,
+  .experience-block,
+  .signature {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  .employer {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines */
+  .paragraph {
+    orphans: 3;
+    widows: 3;
   }
 
   .applicant-contact a {

--- a/templates/modern/styles.css
+++ b/templates/modern/styles.css
@@ -203,7 +203,32 @@
   .application-document {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
+  }
+
+  /* Avoid splitting key sections across page breaks */
+  .application-header,
+  .recipient,
+  .experience,
+  .signature {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Keep employer + first bullet together */
+  .experience-employer {
+    page-break-after: avoid;
+    break-after: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines in body paragraphs */
+  .letter > p,
+  .introduction,
+  .motivation,
+  .closing {
+    orphans: 3;
+    widows: 3;
   }
 
   .contact-information .email {

--- a/templates/resignation-brief/styles.css
+++ b/templates/resignation-brief/styles.css
@@ -103,7 +103,22 @@
   .resignation-brief {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
+  }
+
+  /* Avoid splitting header/recipient/signature across pages */
+  .rb-header,
+  .rb-recipient,
+  .rb-signature {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines */
+  .rb-paragraph {
+    orphans: 3;
+    widows: 3;
   }
 }
 

--- a/templates/resignation-professional/styles.css
+++ b/templates/resignation-professional/styles.css
@@ -143,7 +143,22 @@
   .resignation-professional {
     padding: 0;
     max-width: none;
-    margin: 0 2cm;
+    /* @page in app.vue provides 2cm physical margins; reset CSS margin here */
+    margin: 0;
+  }
+
+  /* Avoid splitting header and recipient across pages */
+  .rp-header,
+  .rp-recipient,
+  .rp-signature-block {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+
+  /* Prevent orphaned/widowed lines in body */
+  .rp-paragraph {
+    orphans: 3;
+    widows: 3;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds a visible **Export PDF** button in the app header that calls `window.print()`
- Hides all editor chrome (header, editor panel, dropdowns, welcome screen) during print via `@media print`
- Adds a global `@page { size: A4; margin: 2cm }` rule for consistent physical page margins
- Resets template CSS margins to `0` (margins now come from `@page` instead of per-template CSS margin rules)
- Cancels any active zoom transform in `PreviewPanel` so document prints at 100%
- Adds `page-break-inside: avoid` + `orphans`/`widows` to all 7 templates (5 cover letter + 2 resignation)
- Creative template sidebar colour preserved with `print-color-adjust: exact`

## Test plan
- [ ] Click **Export PDF** button — browser print dialog opens
- [ ] Print preview shows only the rendered document, no header/editor/chrome
- [ ] All 5 cover-letter templates print cleanly (Modern, Classic, Minimal, Executive, Creative)
- [ ] Creative sidebar background prints in purple (requires "Background graphics" enabled in browser print dialog)
- [ ] Both resignation templates print cleanly (Professional, Brief)
- [ ] Long documents don't split paragraphs or experience blocks mid-sentence across pages
- [ ] Page margins are ~2cm on all sides (A4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)