### PR TITLE
feat: v2 Phase 1 — core AI pipeline, skeleton UI, DOMPurify render (FRG-175)

### DIFF
--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -5,20 +5,21 @@
       v-if="error"
       color="red"
       variant="solid"
-      title="Parsing Error"
+      title="Rendering Error"
       :description="error"
       icon="i-heroicons-exclamation-triangle"
       class="error-alert"
     />
 
-    <!-- Preview Rendering -->
+    <!-- Document Preview — content is DOMPurify-sanitized before assignment to sanitizedHtml -->
+    <!-- eslint-disable vue/no-v-html -->
     <div
-      v-else-if="parsedData && templateComponent"
-      class="preview-container"
+      v-else-if="sanitizedHtml"
+      class="preview-container document-render"
       :style="containerStyle"
-    >
-      <component :is="templateComponent" :data="parsedData" />
-    </div>
+      v-html="sanitizedHtml"
+    />
+    <!-- eslint-enable vue/no-v-html -->
 
     <!-- Placeholder State -->
     <div v-else class="placeholder-state">
@@ -29,8 +30,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
-import { useTemplate } from '~/composables/useTemplate'
-import { parseXml } from '~/composables/useXmlParser'
+import './resume-styles.css'
 
 defineOptions({ name: 'PreviewPanel' })
 
@@ -41,25 +41,43 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), { zoom: 1 })
 
-const parsedData = ref<unknown>(undefined)
+const sanitizedHtml = ref<string>('')
 const error = ref<string | undefined>(undefined)
-
-const { currentTemplate: templateComponent } = useTemplate()
 
 const containerStyle = computed(() => ({
   transform: `scale(${props.zoom})`,
   transformOrigin: 'top left',
 }))
 
-function updatePreview() {
+const ALLOWED_TAGS = [
+  'document', 'header', 'name', 'contact', 'email', 'phone', 'location',
+  'linkedin', 'website', 'summary', 'experience', 'role', 'title', 'company',
+  'period', 'bullets', 'bullet', 'education', 'degree', 'school', 'year',
+  'note', 'skills', 'certifications', 'projects', 'volunteer',
+  // Standard HTML tags DOMPurify allows anyway — kept for section labels
+  'section', 'h2', 'p', 'ul', 'li', 'a', 'br', 'strong', 'em',
+]
+
+const ALLOWED_ATTR = ['type', 'href']
+
+async function updatePreview() {
   error.value = undefined
-  parsedData.value = undefined
-  const result = parseXml(props.xmlContent)
-  if (result.success && result.data) {
-    parsedData.value = result.data
+  sanitizedHtml.value = ''
+
+  if (!props.xmlContent) return
+
+  try {
+    // DOMPurify is browser-only — import lazily to avoid SSR issues
+    const DOMPurify = (await import('dompurify')).default
+    const clean = DOMPurify.sanitize(props.xmlContent, {
+      ADD_TAGS: ALLOWED_TAGS,
+      ADD_ATTR: ALLOWED_ATTR,
+      FORCE_BODY: false,
+    })
+    sanitizedHtml.value = clean
   }
-  else {
-    error.value = result.error || 'Could not parse document'
+  catch (err) {
+    error.value = err instanceof Error ? err.message : 'Could not render document'
   }
 }
 

--- a/components/resume-styles.css
+++ b/components/resume-styles.css
@@ -1,0 +1,222 @@
+/**
+ * Resume / Cover Letter Render Styles
+ *
+ * Styles the custom XML elements produced by the AI pipeline:
+ *   <document>, <header>, <name>, <contact>, <experience>, etc.
+ *
+ * These custom elements are rendered as HTML via DOMPurify + v-html.
+ * The browser treats unknown elements as inline by default, so each
+ * element that needs block-level layout must have display set explicitly.
+ *
+ * Design system:
+ *   --ink:    #111  (body text)
+ *   --muted:  #555  (secondary text)
+ *   --accent: #0f6fec (links / accent)
+ *   --font-body: ui-serif, Georgia, serif
+ *   --font-ui:   ui-sans-serif, system-ui, sans-serif
+ */
+
+/* ── Custom element resets ── */
+document, header, name, contact,
+email, phone, location, linkedin, website,
+summary, experience, role, title, company, period,
+bullets, bullet, education, degree, school, year, note,
+skills, certifications, projects, volunteer {
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Wrapper applied to the rendered content via .document-render ── */
+.document-render {
+  font-family: ui-serif, Georgia, "Times New Roman", Times, serif;
+  font-size: 16px;
+  line-height: 1.6;
+  color: #111;
+  background: #fff;
+}
+
+/* ── document root ── */
+.document-render document {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  background: #fff;
+}
+
+/* ── header block ── */
+.document-render header {
+  border-bottom: 2px solid #111;
+  padding-bottom: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+/* ── applicant name ── */
+.document-render name {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: clamp(1.4rem, 2vw + 1rem, 2rem);
+  font-weight: 600;
+  line-height: 1.2;
+  margin-bottom: 0.5rem;
+}
+
+/* ── contact row ── */
+.document-render contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.document-render email,
+.document-render phone,
+.document-render location,
+.document-render linkedin,
+.document-render website {
+  display: inline;
+}
+
+/* ── section labels via pseudo-elements ── */
+.document-render summary::before,
+.document-render experience::before,
+.document-render education::before,
+.document-render skills::before,
+.document-render certifications::before,
+.document-render projects::before,
+.document-render volunteer::before {
+  display: block;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #555;
+  border-bottom: 1px solid #ddd;
+  padding-bottom: 0.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.document-render summary::before    { content: "Summary"; }
+.document-render experience::before { content: "Experience"; }
+.document-render education::before  { content: "Education"; }
+.document-render skills::before     { content: "Skills"; }
+.document-render certifications::before { content: "Certifications"; }
+.document-render projects::before   { content: "Projects"; }
+.document-render volunteer::before  { content: "Volunteer"; }
+
+/* ── section spacing ── */
+.document-render summary,
+.document-render experience,
+.document-render education,
+.document-render skills,
+.document-render certifications,
+.document-render projects,
+.document-render volunteer {
+  margin-bottom: 1.5rem;
+}
+
+/* ── summary paragraph text ── */
+.document-render summary {
+  color: #111;
+}
+
+/* ── experience roles ── */
+.document-render role {
+  margin-bottom: 1.25rem;
+}
+
+.document-render role:last-child {
+  margin-bottom: 0;
+}
+
+.document-render title {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #111;
+}
+
+.document-render company {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: #555;
+  font-size: 0.9rem;
+}
+
+.document-render period {
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  color: #777;
+  font-size: 0.85rem;
+  margin-bottom: 0.4rem;
+}
+
+/* ── bullets list ── */
+.document-render bullets {
+  padding-left: 1.5rem;
+  margin-top: 0.4rem;
+}
+
+.document-render bullet {
+  display: list-item;
+  list-style-type: disc;
+  color: #111;
+  margin-bottom: 0.2rem;
+  line-height: 1.5;
+}
+
+/* ── education ── */
+.document-render degree {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #111;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+.document-render school,
+.document-render year,
+.document-render note {
+  color: #555;
+  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  font-size: 0.9rem;
+}
+
+/* ── flat text sections ── */
+.document-render skills,
+.document-render certifications,
+.document-render projects,
+.document-render volunteer {
+  color: #111;
+  line-height: 1.7;
+}
+
+/* ── Print ── */
+@media print {
+  .document-render document {
+    padding: 0;
+    max-width: none;
+    margin: 0;
+  }
+
+  .document-render role,
+  .document-render education {
+    page-break-inside: avoid;
+    break-inside: avoid;
+  }
+}
+
+/* ── Responsive ── */
+@media screen and (max-width: 768px) {
+  .document-render document {
+    padding: 1rem 0.75rem;
+  }
+
+  .document-render name {
+    font-size: 1.5rem;
+  }
+
+  .document-render contact {
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,5 +6,9 @@ export default defineNuxtConfig({
 
   devServer: {
     port: 3002
-  }
+  },
+
+  runtimeConfig: {
+    openaiApiKey: process.env.OPENAI_API_KEY || '',
+  },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "dependencies": {
         "@nuxt/eslint": "^1.9.0",
         "@nuxt/ui": "^4.0.1",
+        "@types/dompurify": "^3.0.5",
+        "dompurify": "^3.3.1",
         "htmlparser2": "^10.1.0",
         "nuxt": "^4.1.3",
         "typescript": "^5.9.3",
@@ -4499,6 +4501,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4531,6 +4542,12 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
@@ -7143,6 +7160,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "dependencies": {
     "@nuxt/eslint": "^1.9.0",
     "@nuxt/ui": "^4.0.1",
+    "@types/dompurify": "^3.0.5",
+    "dompurify": "^3.3.1",
     "htmlparser2": "^10.1.0",
     "nuxt": "^4.1.3",
     "typescript": "^5.9.3",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -35,14 +35,49 @@
 
       <!-- Right Panel: Preview -->
       <div class="preview-panel">
-        <div v-if="!formattedXml" class="preview-empty">
+        <!-- Skeleton loading state -->
+        <div v-if="isFormatting" class="skeleton-wrapper">
+          <div class="skeleton skeleton-name" />
+          <div class="skeleton skeleton-contact" />
+          <div class="skeleton-divider" />
+          <div class="skeleton skeleton-line" />
+          <div class="skeleton skeleton-line skeleton-line--short" />
+          <div class="skeleton skeleton-line" />
+          <div class="skeleton-gap" />
+          <div class="skeleton skeleton-heading" />
+          <div class="skeleton skeleton-line" />
+          <div class="skeleton skeleton-line skeleton-line--medium" />
+          <div class="skeleton skeleton-line" />
+          <div class="skeleton skeleton-line skeleton-line--short" />
+          <div class="skeleton-gap" />
+          <div class="skeleton skeleton-heading" />
+          <div class="skeleton skeleton-line skeleton-line--medium" />
+          <div class="skeleton skeleton-line skeleton-line--short" />
+        </div>
+
+        <!-- Error state -->
+        <div v-else-if="formatError" class="error-state">
+          <p class="error-message">{{ formatError }}</p>
+          <UButton variant="outline" @click="formatDocument">
+            Try Again
+          </UButton>
+        </div>
+
+        <!-- Empty state -->
+        <div v-else-if="!formattedXml" class="preview-empty">
           <p>Your formatted document will appear here.</p>
         </div>
-        <PreviewPanel
-          v-else
-          :xml-content="formattedXml"
-          :zoom="1"
-        />
+
+        <!-- Preview + badge -->
+        <template v-else>
+          <PreviewPanel
+            :xml-content="formattedXml"
+            :zoom="1"
+          />
+          <div v-if="documentType" class="document-badge">
+            {{ documentType === 'resume' ? 'Resume detected' : 'Cover letter detected' }} ✓
+          </div>
+        </template>
       </div>
     </div>
   </div>
@@ -66,6 +101,8 @@ Software Engineer with 8 years...`
 const textContent = ref('')
 const formattedXml = ref('')
 const isFormatting = ref(false)
+const formatError = ref('')
+const documentType = ref('')
 
 function handlePrint() {
   window.print()
@@ -74,15 +111,21 @@ function handlePrint() {
 async function formatDocument() {
   if (!textContent.value.trim() || isFormatting.value) return
   isFormatting.value = true
+  formatError.value = ''
+  formattedXml.value = ''
+  documentType.value = ''
+
   try {
     const result = await $fetch<{ xml: string, divergence: number, documentType: string }>('/api/format', {
       method: 'POST',
       body: { text: textContent.value },
     })
     formattedXml.value = result.xml
+    documentType.value = result.documentType
   }
-  catch (err) {
-    console.error('Format error:', err)
+  catch (err: unknown) {
+    const message = (err as { data?: { message?: string } })?.data?.message
+    formatError.value = message || 'Something went wrong. Please try again.'
   }
   finally {
     isFormatting.value = false
@@ -140,6 +183,7 @@ async function formatDocument() {
   flex-direction: column;
   overflow: auto;
   background-color: var(--color-gray-50);
+  position: relative;
 }
 
 .preview-empty {
@@ -149,6 +193,106 @@ async function formatDocument() {
   justify-content: center;
   color: var(--color-gray-400);
   font-size: 0.875rem;
+}
+
+/* ── Skeleton loading UI ── */
+.skeleton-wrapper {
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-gray-200) 25%,
+    var(--color-gray-100) 50%,
+    var(--color-gray-200) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+  border-radius: 4px;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.skeleton-name {
+  height: 2rem;
+  width: 55%;
+  margin-bottom: 0.25rem;
+}
+
+.skeleton-contact {
+  height: 1rem;
+  width: 70%;
+  margin-bottom: 0.5rem;
+}
+
+.skeleton-divider {
+  height: 2px;
+  background: var(--color-gray-200);
+  margin: 0.75rem 0;
+  border-radius: 0;
+}
+
+.skeleton-line {
+  height: 0.875rem;
+  width: 100%;
+}
+
+.skeleton-line--short {
+  width: 55%;
+}
+
+.skeleton-line--medium {
+  width: 75%;
+}
+
+.skeleton-gap {
+  height: 1rem;
+}
+
+.skeleton-heading {
+  height: 1rem;
+  width: 30%;
+  margin-bottom: 0.25rem;
+}
+
+/* ── Error state ── */
+.error-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.error-message {
+  color: var(--color-red-600);
+  font-size: 0.9rem;
+  text-align: center;
+  max-width: 320px;
+}
+
+/* ── Document type badge ── */
+.document-badge {
+  position: sticky;
+  bottom: 0;
+  align-self: flex-start;
+  margin: 0 1.25rem 1rem;
+  padding: 0.35rem 0.75rem;
+  background: #ecfdf5;
+  color: #065f46;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border-radius: 9999px;
+  border: 1px solid #6ee7b7;
 }
 
 @media print {
@@ -173,6 +317,10 @@ async function formatDocument() {
 
   .preview-panel {
     background: transparent;
+  }
+
+  .document-badge {
+    display: none;
   }
 }
 

--- a/server/api/format.post.ts
+++ b/server/api/format.post.ts
@@ -1,8 +1,144 @@
+import { Parser } from 'htmlparser2'
+
+const SYSTEM_PROMPT = `You are a professional document formatter. Convert plain-text resumes and cover letters into structured XML.
+
+For resumes use this schema:
+<document type="resume">
+  <header>
+    <name>Full Name</name>
+    <contact>
+      <email>email@example.com</email>
+      <phone>555-000-0000</phone>
+      <location>City, State</location>
+      <linkedin>linkedin.com/in/username</linkedin>
+      <website>portfolio.com</website>
+    </contact>
+  </header>
+  <summary>Professional summary text.</summary>
+  <experience>
+    <role>
+      <title>Job Title</title>
+      <company>Company Name</company>
+      <period>Month Year – Month Year</period>
+      <bullets>
+        <bullet>Key achievement or responsibility</bullet>
+      </bullets>
+    </role>
+  </experience>
+  <education>
+    <degree>Degree Name</degree>
+    <school>School Name</school>
+    <year>Graduation Year</year>
+    <note>Honors or relevant note</note>
+  </education>
+  <skills>Skill 1, Skill 2, Skill 3</skills>
+  <certifications>Cert 1, Cert 2</certifications>
+  <projects>Project descriptions</projects>
+  <volunteer>Volunteer experience</volunteer>
+</document>
+
+For cover letters use type="cover-letter" and adapt content into letter sections using summary (opening), experience (body paragraphs), and closing elements.
+
+Rules:
+- Preserve ALL information from the source text
+- Omit empty optional tags
+- Output ONLY valid XML — no markdown fences, no explanation
+- Detect whether the input is a resume or cover letter and set the type attribute accordingly`
+
+interface OpenAIChatResponse {
+  choices: Array<{
+    message: {
+      content: string
+    }
+  }>
+}
+
+function extractTextFromXml(xmlString: string): string {
+  const textParts: string[] = []
+  const parser = new Parser({
+    ontext(text) {
+      textParts.push(text)
+    },
+  }, { decodeEntities: true })
+  parser.write(xmlString)
+  parser.end()
+  return textParts.join(' ')
+}
+
+function detectDocumentType(xmlString: string): string {
+  const match = xmlString.match(/<document[^>]+type="([^"]+)"/)
+  return match?.[1] ?? 'resume'
+}
+
+function validateXmlStructure(xmlString: string): boolean {
+  let valid = true
+  let depth = 0
+  const parser = new Parser({
+    onerror() {
+      valid = false
+    },
+    onopentag() {
+      depth++
+    },
+    onclosetag() {
+      depth--
+      if (depth < 0) valid = false
+    },
+  }, { xmlMode: true })
+  parser.write(xmlString)
+  parser.end()
+  return valid && depth === 0
+}
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
+
   if (!body.text || body.text.length < 50) {
     throw createError({ statusCode: 400, message: 'Paste more content to format.' })
   }
-  // Phase 1 will add the OpenAI call here
-  return { xml: '<document type="resume"><header><name>Placeholder</name></header></document>', divergence: 0, documentType: 'resume' }
+
+  const config = useRuntimeConfig()
+
+  if (!config.openaiApiKey) {
+    throw createError({ statusCode: 500, message: 'OpenAI API key is not configured.' })
+  }
+
+  const inputLen = body.text.length
+
+  const response = await $fetch<OpenAIChatResponse>('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${config.openaiApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: body.text },
+      ],
+      temperature: 0.3,
+      max_tokens: 4000,
+    },
+  })
+
+  const raw = response.choices[0]?.message?.content ?? ''
+
+  // Strip markdown fences if present
+  const xml = raw
+    .replace(/^```(?:xml)?\n?/m, '')
+    .replace(/\n?```$/m, '')
+    .trim()
+
+  if (!validateXmlStructure(xml)) {
+    throw createError({ statusCode: 502, message: 'AI returned malformed XML. Please try again.' })
+  }
+
+  const xmlText = extractTextFromXml(xml)
+  const xmlTextLen = xmlText.length
+  const divergence = Math.abs(inputLen - xmlTextLen) / inputLen
+
+  const documentType = detectDocumentType(xml)
+
+  return { xml, divergence, documentType }
 })

--- a/tests/e2e/task-2-xml-parser.spec.ts
+++ b/tests/e2e/task-2-xml-parser.spec.ts
@@ -375,7 +375,7 @@ test.describe('Task 2: XML Parser - UI Interactions', () => {
     await page.goto('/debug/parser');
 
     // Check for loading alert (might be brief)
-    const loadingAlert = page.locator('[role="alert"]:has-text("Loading Sample XML")');
+    const _loadingAlert = page.locator('[role="alert"]:has-text("Loading Sample XML")');
     // Loading alert may disappear quickly, so we just check page loads
     await page.waitForLoadState('networkidle');
 


### PR DESCRIPTION
## Summary
- **Server route** (`/server/api/format.post.ts`): replaces placeholder with a real OpenAI `gpt-4o-mini` call — accepts `{ text }`, rejects < 50 chars, strips markdown fences, validates XML with `htmlparser2`, computes mutation divergence, returns `{ xml, divergence, documentType }`
- **Client** (`pages/index.vue`): shows a CSS shimmer skeleton during loading, user-friendly error message + "Try Again" button on failure, and a "Resume detected ✓ / Cover letter detected ✓" badge after success
- **Preview** (`components/PreviewPanel.vue`): switches from the old `parseXml` / Vue-component approach to `DOMPurify.sanitize` + `v-html`, allowing the new `<document type="resume|cover-letter">` XML schema to render directly as HTML
- **Styles** (`components/resume-styles.css`): sets `display: block` and typographic styles for each custom XML element (`name`, `contact`, `role`, `bullet`, `education`, etc.)
- **Config** (`nuxt.config.ts`): exposes `openaiApiKey` via `runtimeConfig` (reads `OPENAI_API_KEY` env var)
- **Dep** (`package.json`): adds `dompurify` + `@types/dompurify`
- **Test fix** (`tests/e2e/task-2-xml-parser.spec.ts`): prefix unused var with `_` to satisfy eslint

## Test plan
- [ ] Set `OPENAI_API_KEY` in `.env` and start dev server (`npm run dev`)
- [ ] Paste 50+ chars of resume text → click "Format My Resume"
- [ ] Verify skeleton shimmer appears during loading
- [ ] Verify formatted resume renders with name, contact, experience sections
- [ ] Verify "Resume detected ✓" badge appears below preview
- [ ] Paste cover letter text → verify "Cover letter detected ✓" badge
- [ ] Test error path: temporarily remove API key → verify error message + "Try Again" button
- [ ] Run `npm run lint` — 0 errors
- [ ] Run `npm run build` — successful

## Key decisions
- **DOMPurify `ADD_TAGS` (not `CUSTOM_ELEMENT_HANDLING`)**: matches the issue spec; allows the exact list of custom tags while blocking anything else
- **`resume-styles.css` co-located in `components/`**: the styles only make sense alongside `PreviewPanel`; a `templates/` subdirectory would imply a swappable template which doesn't exist yet for this schema
- **Lazy `import('dompurify')`**: DOMPurify is browser-only; dynamic import avoids SSR crash without needing `<ClientOnly>` wrapper on the whole panel

Closes FRG-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)