### PR TITLE
feat: Phase 2 — preview polish, PDF export, mutation warning, error states (FRG-176)

### DIFF
--- a/components/resume-styles.css
+++ b/components/resume-styles.css
@@ -1,5 +1,5 @@
 /**
- * Resume / Cover Letter Render Styles
+ * Resume / Cover Letter Render Styles — modern.css spec
  *
  * Styles the custom XML elements produced by the AI pipeline:
  *   <document>, <header>, <name>, <contact>, <experience>, etc.
@@ -8,12 +8,13 @@
  * The browser treats unknown elements as inline by default, so each
  * element that needs block-level layout must have display set explicitly.
  *
- * Design system:
- *   --ink:    #111  (body text)
- *   --muted:  #555  (secondary text)
- *   --accent: #0f6fec (links / accent)
- *   --font-body: ui-serif, Georgia, serif
- *   --font-ui:   ui-sans-serif, system-ui, sans-serif
+ * Design spec:
+ *   Font:      Inter, 'DM Sans', system-ui, -apple-system, sans-serif
+ *   Name:      22px / 700
+ *   Sections:  13px / 600 / ALL CAPS / letter-spacing 0.05em / border-bottom 1.5px solid
+ *   Body:      13px / 400 / line-height 1.5
+ *   Contact:   12px / #555
+ *   Layout:    max-width 800px, padding 48px 64px
  */
 
 /* ── Custom element resets ── */
@@ -29,44 +30,42 @@ skills, certifications, projects, volunteer {
 
 /* ── Wrapper applied to the rendered content via .document-render ── */
 .document-render {
-  font-family: ui-serif, Georgia, "Times New Roman", Times, serif;
-  font-size: 16px;
-  line-height: 1.6;
+  font-family: Inter, 'DM Sans', system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
   color: #111;
   background: #fff;
 }
 
 /* ── document root ── */
 .document-render document {
-  max-width: 720px;
+  max-width: 800px;
   margin: 0 auto;
-  padding: 2rem 1rem;
+  padding: 48px 64px;
   background: #fff;
 }
 
 /* ── header block ── */
 .document-render header {
-  border-bottom: 2px solid #111;
-  padding-bottom: 1rem;
   margin-bottom: 1.5rem;
 }
 
 /* ── applicant name ── */
 .document-render name {
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  font-size: clamp(1.4rem, 2vw + 1rem, 2rem);
-  font-weight: 600;
+  font-size: 22px;
+  font-weight: 700;
   line-height: 1.2;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.4rem;
+  color: #111;
 }
 
 /* ── contact row ── */
 .document-render contact {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem 1rem;
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  font-size: 0.9rem;
+  gap: 0.2rem 0.75rem;
+  font-size: 12px;
   color: #555;
 }
 
@@ -87,15 +86,15 @@ skills, certifications, projects, volunteer {
 .document-render projects::before,
 .document-render volunteer::before {
   display: block;
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.12em;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: #555;
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 0.2rem;
+  color: #111;
+  border-bottom: 1.5px solid #111;
+  padding-bottom: 0.25rem;
   margin-bottom: 0.75rem;
+  margin-top: 0;
 }
 
 .document-render summary::before    { content: "Summary"; }
@@ -114,7 +113,7 @@ skills, certifications, projects, volunteer {
 .document-render certifications,
 .document-render projects,
 .document-render volunteer {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
 /* ── summary paragraph text ── */
@@ -124,37 +123,77 @@ skills, certifications, projects, volunteer {
 
 /* ── experience roles ── */
 .document-render role {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .document-render role:last-child {
   margin-bottom: 0;
 }
 
-.document-render title {
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+/* ── role header: title + period on same line via flexbox ── */
+.document-render role > title,
+.document-render role > period {
+  display: inline-block;
+}
+
+.document-render role {
+  position: relative;
+}
+
+/* Use a flex row for title + period using a pseudo wrapper approach via display flex on role */
+.document-render role > title {
+  display: inline;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 13px;
   color: #111;
 }
 
-.document-render company {
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+.document-render role > company {
+  font-size: 13px;
   color: #555;
-  font-size: 0.9rem;
+  margin-bottom: 0.1rem;
 }
 
-.document-render period {
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  color: #777;
-  font-size: 0.85rem;
-  margin-bottom: 0.4rem;
+/* Title + period on same line: role acts as flex container for title/period */
+.document-render role {
+  display: block;
+}
+
+/* We achieve "title left, period right" by wrapping them in a flex row */
+/* Since we control the XML schema, we wrap via CSS trick: title + period as a pseudo flex row */
+/* We use a separate div approach — but since we can't add wrappers, we use display:flex on role */
+/* and constrain bullets to be display:block to break out */
+.document-render role > bullets {
+  display: block;
+  flex: 0 0 100%;
+}
+
+/* Flex layout for role row: title + period */
+.document-render role {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 0.5rem;
+}
+
+/* Force company and bullets to take full width */
+.document-render role > company,
+.document-render role > bullets {
+  flex: 0 0 100%;
+}
+
+/* Period pushes to the right */
+.document-render role > period {
+  margin-left: auto;
+  font-size: 13px;
+  color: #555;
+  white-space: nowrap;
 }
 
 /* ── bullets list ── */
 .document-render bullets {
-  padding-left: 1.5rem;
-  margin-top: 0.4rem;
+  padding-left: 1.25rem;
+  margin-top: 0.35rem;
 }
 
 .document-render bullet {
@@ -163,22 +202,21 @@ skills, certifications, projects, volunteer {
   color: #111;
   margin-bottom: 0.2rem;
   line-height: 1.5;
+  font-size: 13px;
 }
 
 /* ── education ── */
 .document-render degree {
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 13px;
   color: #111;
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
 }
 
 .document-render school,
 .document-render year,
 .document-render note {
   color: #555;
-  font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-  font-size: 0.9rem;
+  font-size: 13px;
 }
 
 /* ── flat text sections ── */
@@ -187,11 +225,23 @@ skills, certifications, projects, volunteer {
 .document-render projects,
 .document-render volunteer {
   color: #111;
-  line-height: 1.7;
+  line-height: 1.5;
+  font-size: 13px;
+}
+
+/* ── links ── */
+.document-render a {
+  color: #0f6fec;
+  text-decoration: none;
 }
 
 /* ── Print ── */
 @media print {
+  @page {
+    size: A4;
+    margin: 0.75in;
+  }
+
   .document-render document {
     padding: 0;
     max-width: none;
@@ -203,16 +253,21 @@ skills, certifications, projects, volunteer {
     page-break-inside: avoid;
     break-inside: avoid;
   }
+
+  .document-render a {
+    color: #111 !important;
+    text-decoration: none !important;
+  }
 }
 
 /* ── Responsive ── */
 @media screen and (max-width: 768px) {
   .document-render document {
-    padding: 1rem 0.75rem;
+    padding: 1.5rem 1rem;
   }
 
   .document-render name {
-    font-size: 1.5rem;
+    font-size: 18px;
   }
 
   .document-render contact {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,42 +1,55 @@
 <template>
   <div class="app-container">
-    <AppHeader>
+    <AppHeader class="app-header no-print">
       <template #right-actions>
-        <UButton
-          size="xs"
-          variant="outline"
-          icon="i-heroicons-printer"
-          @click="handlePrint"
-        >
-          Export PDF
-        </UButton>
+        <div class="export-area no-print">
+          <div v-if="showDivergenceWarning" class="divergence-warning">
+            ⚠ Some content may have been changed during formatting. Please review carefully before exporting.
+          </div>
+          <UButton
+            size="xs"
+            variant="outline"
+            icon="i-heroicons-printer"
+            :disabled="!formattedXml"
+            @click="handlePrint"
+          >
+            Export PDF
+          </UButton>
+          <span class="export-hint">Works best in Chrome. In the print dialog, choose 'Save as PDF'.</span>
+        </div>
       </template>
     </AppHeader>
 
     <!-- Dual-panel layout: Text input (left) and Preview (right) -->
     <div class="dual-panel-layout">
       <!-- Left Panel: Plain text input -->
-      <div class="editor-panel">
+      <div class="editor-panel no-print">
         <textarea
           v-model="textContent"
           class="text-input"
           :placeholder="placeholder"
+          :disabled="isFormatting"
         />
         <div class="action-bar">
-          <UButton
-            :disabled="!textContent.trim() || isFormatting"
-            :loading="isFormatting"
-            @click="formatDocument"
-          >
-            {{ isFormatting ? 'Formatting...' : 'Format My Resume' }}
-          </UButton>
+          <div class="action-row">
+            <UButton
+              :disabled="!textContent.trim() || isFormatting"
+              :loading="isFormatting"
+              @click="formatDocument"
+            >
+              {{ isFormatting ? 'Formatting...' : 'Format My Resume' }}
+            </UButton>
+            <p v-if="validationMessage" class="validation-message">
+              {{ validationMessage }}
+            </p>
+          </div>
         </div>
       </div>
 
       <!-- Right Panel: Preview -->
       <div class="preview-panel">
         <!-- Skeleton loading state -->
-        <div v-if="isFormatting" class="skeleton-wrapper">
+        <div v-if="isFormatting" class="skeleton-wrapper no-print">
           <div class="skeleton skeleton-name" />
           <div class="skeleton skeleton-contact" />
           <div class="skeleton-divider" />
@@ -56,7 +69,7 @@
         </div>
 
         <!-- Error state -->
-        <div v-else-if="formatError" class="error-state">
+        <div v-else-if="formatError" class="error-state no-print">
           <p class="error-message">{{ formatError }}</p>
           <UButton variant="outline" @click="formatDocument">
             Try Again
@@ -64,18 +77,18 @@
         </div>
 
         <!-- Empty state -->
-        <div v-else-if="!formattedXml" class="preview-empty">
+        <div v-else-if="!formattedXml" class="preview-empty no-print">
           <p>Your formatted document will appear here.</p>
         </div>
 
-        <!-- Preview + badge -->
+        <!-- Preview + review note -->
         <template v-else>
           <PreviewPanel
             :xml-content="formattedXml"
             :zoom="1"
           />
-          <div v-if="documentType" class="document-badge">
-            {{ documentType === 'resume' ? 'Resume detected' : 'Cover letter detected' }} ✓
+          <div class="review-note no-print">
+            Your content has been formatted but not rewritten. Please review before exporting.
           </div>
         </template>
       </div>
@@ -84,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 useHead({
   title: 'OhMyDoc',
@@ -103,17 +116,32 @@ const formattedXml = ref('')
 const isFormatting = ref(false)
 const formatError = ref('')
 const documentType = ref('')
+const divergence = ref(0)
+const validationMessage = ref('')
+
+const showDivergenceWarning = computed(() => formattedXml.value && divergence.value > 0.05)
 
 function handlePrint() {
   window.print()
 }
 
 async function formatDocument() {
-  if (!textContent.value.trim() || isFormatting.value) return
+  validationMessage.value = ''
+
+  if (!textContent.value.trim()) return
+
+  if (textContent.value.trim().length < 50) {
+    validationMessage.value = 'Please paste at least 50 characters of content to format.'
+    return
+  }
+
+  if (isFormatting.value) return
+
   isFormatting.value = true
   formatError.value = ''
   formattedXml.value = ''
   documentType.value = ''
+  divergence.value = 0
 
   try {
     const result = await $fetch<{ xml: string, divergence: number, documentType: string }>('/api/format', {
@@ -122,8 +150,13 @@ async function formatDocument() {
     })
     formattedXml.value = result.xml
     documentType.value = result.documentType
+    divergence.value = result.divergence
   }
   catch (err: unknown) {
+    const raw = (err as { data?: { rawResponse?: string } })?.data?.rawResponse
+    if (raw) {
+      console.error('[OhMyDoc] Raw AI response (malformed XML):', raw)
+    }
     const message = (err as { data?: { message?: string } })?.data?.message
     formatError.value = message || 'Something went wrong. Please try again.'
   }
@@ -172,10 +205,27 @@ async function formatDocument() {
   min-height: 0;
 }
 
+.text-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .action-bar {
   padding: 0.75rem 1.25rem;
   border-top: 1px solid var(--color-gray-200);
   background-color: var(--color-gray-50);
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.validation-message {
+  font-size: 0.8rem;
+  color: var(--color-amber-600, #d97706);
 }
 
 .preview-panel {
@@ -280,34 +330,52 @@ async function formatDocument() {
   max-width: 320px;
 }
 
-/* ── Document type badge ── */
-.document-badge {
-  position: sticky;
-  bottom: 0;
-  align-self: flex-start;
-  margin: 0 1.25rem 1rem;
-  padding: 0.35rem 0.75rem;
-  background: #ecfdf5;
-  color: #065f46;
-  font-size: 0.8rem;
-  font-weight: 500;
-  border-radius: 9999px;
-  border: 1px solid #6ee7b7;
+/* ── Review / mutation note ── */
+.review-note {
+  padding: 0.6rem 1.25rem;
+  font-size: 0.75rem;
+  color: var(--color-gray-500);
+  background: var(--color-gray-50);
+  border-top: 1px solid var(--color-gray-200);
+  text-align: center;
 }
 
+/* ── Export area in header ── */
+.export-area {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.export-hint {
+  font-size: 0.7rem;
+  color: var(--color-gray-400);
+  white-space: nowrap;
+}
+
+/* ── Divergence / mutation warning ── */
+.divergence-warning {
+  font-size: 0.75rem;
+  color: #92400e;
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 4px;
+  padding: 0.3rem 0.6rem;
+  max-width: 360px;
+}
+
+/* ── Print ── */
 @media print {
+  .no-print {
+    display: none !important;
+  }
+
   .app-container {
     display: block;
     height: auto;
     overflow: visible;
-  }
-
-  .app-header {
-    display: none;
-  }
-
-  .editor-panel {
-    display: none;
   }
 
   .dual-panel-layout {
@@ -317,10 +385,7 @@ async function formatDocument() {
 
   .preview-panel {
     background: transparent;
-  }
-
-  .document-badge {
-    display: none;
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
## Summary

- **CSS overhaul**: `resume-styles.css` rewritten to the `modern.css` spec — Inter/DM Sans font, 13px body, 22px/700 name, 13px/600 ALL-CAPS section headers with 1.5px solid bottom border, 800px max-width, 48px 64px padding, flexbox role row (title left, period right), `@page { size: A4; margin: 0.75in }`, print links as black text
- **Mutation warning**: Neutral review note always shown below preview; amber banner above Export button when divergence > 5%
- **PDF export**: `window.print()` + `.no-print` class on all UI chrome (header, editor, warnings, badges); `@page` print rule; `page-break-inside: avoid` on sections
- **Input validation**: Client-side 50-char minimum with inline message; textarea disabled during generation; Export PDF button disabled until document rendered
- **Error states**: API errors show user-friendly message + Try Again; malformed XML response logged to console; short input blocked client-side before API call

## Test plan

- [ ] Paste < 50 chars → inline validation message appears, no API call made
- [ ] Textarea is disabled/greyed-out while formatting
- [ ] Format a resume → preview renders with Inter font, correct sizes, section headers uppercase with border
- [ ] Divergence > 5% → amber warning banner shown above Export PDF
- [ ] Review note always appears below preview once formatted
- [ ] Export PDF → window.print() fires, only document renders (no panels/header/warnings)
- [ ] API key missing/network error → "Something went wrong. Please try again." + Try Again button

🤖 Generated with [Claude Code](https://claude.com/claude-code)