### PR TITLE
feat: configure Cloudflare Pages deployment (FRG-177)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,6 +8,13 @@ export default defineNuxtConfig({
     port: 3002
   },
 
+  // Target Cloudflare Pages + Workers for deployment.
+  // Vercel Git integration automatically overrides this via NITRO_PRESET=vercel.
+  // For manual Vercel CLI deploys, set NITRO_PRESET=vercel in your environment.
+  nitro: {
+    preset: 'cloudflare-pages',
+  },
+
   runtimeConfig: {
     openaiApiKey: process.env.OPENAI_API_KEY || '',
   },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,18 @@
+# Cloudflare Pages + Workers configuration
+# https://developers.cloudflare.com/pages/configuration/wrangler-configuration/
+name = "ohmydoc"
+compatibility_date = "2025-07-15"
+
+# Required for Node.js compatibility (used by htmlparser2 and Nuxt server)
+compatibility_flags = ["nodejs_compat"]
+
+# Cloudflare Pages build output directory (Nitro cloudflare-pages preset outputs here)
+pages_build_output_dir = "dist"
+
+# Environment variables — secrets must be set separately via:
+#   npx wrangler secret put OPENAI_API_KEY
+# Or via the Cloudflare Pages dashboard > Settings > Environment variables.
+# Never commit API keys to this file.
+#
+# [vars]
+# OPENAI_API_KEY = ""  # ← DO NOT set secrets here; use wrangler secret put instead


### PR DESCRIPTION
## Summary
- Add `nitro.preset = 'cloudflare-pages'` to `nuxt.config.ts` so Nuxt/Nitro targets the Cloudflare Pages + Workers runtime at build time
- Add `wrangler.toml` with Cloudflare Pages configuration: `nodejs_compat` flag (required for `htmlparser2`), build output directory, and guidance for setting `OPENAI_API_KEY` as a secret

## Deployment Instructions (Cloudflare)

**Build:**
```bash
npx nuxt build
```

**Deploy via Wrangler CLI:**
```bash
npx wrangler pages deploy dist
```

**Set the API key secret (one-time):**
```bash
npx wrangler secret put OPENAI_API_KEY
```

**Or via Cloudflare Pages Git Integration:**
- Connect GitHub repo in the Cloudflare Pages dashboard
- Build command: `npx nuxt build`
- Output directory: `dist`
- Add `OPENAI_API_KEY` under Settings → Environment variables (use "Secret" type)

## Keeping Vercel Working

Vercel's Git integration automatically sets `NITRO_PRESET=vercel` during its build, which overrides the `cloudflare-pages` preset in `nuxt.config.ts`. Existing Vercel deployments are unaffected.

## Test plan
- [x] `nuxt build` succeeds and emits `dist/_worker.js` (Cloudflare Workers entrypoint)
- [x] `dist/_routes.json`, `dist/_headers`, `dist/_redirects` generated (Cloudflare Pages artifacts)
- [x] `/api/format` server route compiled into `dist/_worker.js/chunks/routes/api/format.post.mjs`
- [x] No linting errors in changed files
- [ ] Verify end-to-end on deployed Cloudflare Pages URL (requires secrets to be set)

Closes FRG-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)