### PR TITLE
feat: add letter document type with doc type selector (FRG-216)

### DIFF
--- a/components/PreviewPanel.vue
+++ b/components/PreviewPanel.vue
@@ -50,10 +50,13 @@ const containerStyle = computed(() => ({
 }))
 
 const ALLOWED_TAGS = [
+  // Resume elements
   'document', 'header', 'name', 'contact', 'email', 'phone', 'location',
   'linkedin', 'website', 'summary', 'experience', 'role', 'title', 'company',
   'period', 'bullets', 'bullet', 'education', 'degree', 'school', 'year',
   'note', 'skills', 'certifications', 'projects', 'volunteer',
+  // Cover-letter elements
+  'date', 'recipient', 'greeting', 'body', 'paragraph', 'closing', 'signature',
   // Standard HTML tags DOMPurify allows anyway — kept for section labels
   'section', 'h2', 'p', 'ul', 'li', 'a', 'br', 'strong', 'em',
 ]

--- a/components/resume-styles.css
+++ b/components/resume-styles.css
@@ -22,7 +22,8 @@ document, header, name, contact,
 email, phone, location, linkedin, website,
 summary, experience, role, title, company, period,
 bullets, bullet, education, degree, school, year, note,
-skills, certifications, projects, volunteer {
+skills, certifications, projects, volunteer,
+date, recipient, greeting, body, paragraph, closing, signature {
   display: block;
   margin: 0;
   padding: 0;
@@ -233,6 +234,82 @@ skills, certifications, projects, volunteer {
 .document-render a {
   color: #0f6fec;
   text-decoration: none;
+}
+
+/* ══════════════════════════════════════════════
+   Cover Letter styles  (document[type="cover-letter"])
+   ══════════════════════════════════════════════ */
+
+/* Shared header reuse — contact inline for letter too */
+.document-render document[type="cover-letter"] contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem 0.75rem;
+  font-size: 12px;
+  color: #555;
+}
+
+/* Date line */
+.document-render document[type="cover-letter"] date {
+  font-size: 13px;
+  color: #111;
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Recipient block */
+.document-render recipient {
+  margin-bottom: 1.5rem;
+  font-size: 13px;
+  color: #111;
+  line-height: 1.6;
+}
+
+.document-render recipient > name {
+  font-weight: 600;
+}
+
+.document-render recipient > title,
+.document-render recipient > company,
+.document-render recipient > address {
+  color: #555;
+}
+
+/* Greeting */
+.document-render greeting {
+  font-size: 13px;
+  color: #111;
+  margin-bottom: 1rem;
+}
+
+/* Body paragraphs */
+.document-render body {
+  margin-bottom: 1rem;
+}
+
+.document-render paragraph {
+  font-size: 13px;
+  color: #111;
+  line-height: 1.6;
+  margin-bottom: 0.85rem;
+}
+
+.document-render paragraph:last-child {
+  margin-bottom: 0;
+}
+
+/* Closing + signature */
+.document-render closing {
+  font-size: 13px;
+  color: #111;
+  margin-top: 1.5rem;
+}
+
+.document-render signature {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111;
+  margin-top: 2.5rem;
 }
 
 /* ── Print ── */

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,13 +31,31 @@
           :disabled="isFormatting"
         />
         <div class="action-bar">
+          <div class="type-selector">
+            <button
+              class="type-btn"
+              :class="{ 'type-btn--active': selectedDocType === 'resume' }"
+              :disabled="isFormatting"
+              @click="selectedDocType = 'resume'"
+            >
+              Resume
+            </button>
+            <button
+              class="type-btn"
+              :class="{ 'type-btn--active': selectedDocType === 'letter' }"
+              :disabled="isFormatting"
+              @click="selectedDocType = 'letter'"
+            >
+              Letter
+            </button>
+          </div>
           <div class="action-row">
             <UButton
               :disabled="!textContent.trim() || isFormatting"
               :loading="isFormatting"
               @click="formatDocument"
             >
-              {{ isFormatting ? 'Formatting...' : 'Format My Resume' }}
+              {{ isFormatting ? 'Formatting...' : formatButtonLabel }}
             </UButton>
             <p v-if="validationMessage" class="validation-message">
               {{ validationMessage }}
@@ -118,6 +136,11 @@ const formatError = ref('')
 const documentType = ref('')
 const divergence = ref(0)
 const validationMessage = ref('')
+const selectedDocType = ref<'resume' | 'letter'>('resume')
+
+const formatButtonLabel = computed(() =>
+  selectedDocType.value === 'letter' ? 'Format My Letter' : 'Format My Resume',
+)
 
 const showDivergenceWarning = computed(() => formattedXml.value && divergence.value > 0.05)
 
@@ -146,7 +169,7 @@ async function formatDocument() {
   try {
     const result = await $fetch<{ xml: string, divergence: number, documentType: string }>('/api/format', {
       method: 'POST',
-      body: { text: textContent.value },
+      body: { text: textContent.value, docType: selectedDocType.value },
     })
     formattedXml.value = result.xml
     documentType.value = result.documentType
@@ -214,6 +237,48 @@ async function formatDocument() {
   padding: 0.75rem 1.25rem;
   border-top: 1px solid var(--color-gray-200);
   background-color: var(--color-gray-50);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.type-selector {
+  display: flex;
+  gap: 0;
+  width: fit-content;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.type-btn {
+  padding: 0.3rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: none;
+  background: #fff;
+  color: var(--color-gray-600);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+  line-height: 1.5;
+}
+
+.type-btn:first-child {
+  border-right: 1px solid var(--color-gray-300);
+}
+
+.type-btn--active {
+  background-color: var(--color-gray-900);
+  color: #fff;
+}
+
+.type-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.type-btn:not(:disabled):not(.type-btn--active):hover {
+  background-color: var(--color-gray-100);
 }
 
 .action-row {

--- a/server/api/format.post.ts
+++ b/server/api/format.post.ts
@@ -1,8 +1,8 @@
 import { Parser } from 'htmlparser2'
 
-const SYSTEM_PROMPT = `You are a professional document formatter. Convert plain-text resumes and cover letters into structured XML.
+const RESUME_SYSTEM_PROMPT = `You are a professional document formatter. Convert plain-text resumes into structured XML.
 
-For resumes use this schema:
+Use this schema:
 <document type="resume">
   <header>
     <name>Full Name</name>
@@ -37,13 +37,45 @@ For resumes use this schema:
   <volunteer>Volunteer experience</volunteer>
 </document>
 
-For cover letters use type="cover-letter" and adapt content into letter sections using summary (opening), experience (body paragraphs), and closing elements.
-
 Rules:
 - Preserve ALL information from the source text
 - Omit empty optional tags
-- Output ONLY valid XML — no markdown fences, no explanation
-- Detect whether the input is a resume or cover letter and set the type attribute accordingly`
+- Output ONLY valid XML — no markdown fences, no explanation`
+
+const LETTER_SYSTEM_PROMPT = `You are a professional document formatter. Convert plain-text cover letters or letters into structured XML.
+
+Use this schema:
+<document type="cover-letter">
+  <header>
+    <name>Sender Full Name</name>
+    <contact>
+      <email>email@example.com</email>
+      <phone>555-000-0000</phone>
+      <location>City, State</location>
+    </contact>
+  </header>
+  <date>Month Day, Year</date>
+  <recipient>
+    <name>Recipient Name</name>
+    <title>Recipient Title</title>
+    <company>Company Name</company>
+    <address>City, State</address>
+  </recipient>
+  <greeting>Dear Hiring Manager,</greeting>
+  <body>
+    <paragraph>Opening paragraph text.</paragraph>
+    <paragraph>Body paragraph text.</paragraph>
+    <paragraph>Closing paragraph text.</paragraph>
+  </body>
+  <closing>Sincerely,</closing>
+  <signature>Sender Full Name</signature>
+</document>
+
+Rules:
+- Preserve ALL information from the source text
+- Split letter body into logical paragraphs
+- Omit empty optional tags (e.g. omit <date> if no date found, omit recipient <name> if unknown)
+- Output ONLY valid XML — no markdown fences, no explanation`
 
 interface OpenAIChatResponse {
   choices: Array<{
@@ -105,6 +137,10 @@ export default defineEventHandler(async (event) => {
 
   const inputLen = body.text.length
 
+  // Select system prompt based on client-supplied docType; fall back to resume
+  const docType: string = body.docType === 'letter' ? 'letter' : 'resume'
+  const systemPrompt = docType === 'letter' ? LETTER_SYSTEM_PROMPT : RESUME_SYSTEM_PROMPT
+
   const response = await $fetch<OpenAIChatResponse>('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -114,7 +150,7 @@ export default defineEventHandler(async (event) => {
     body: {
       model: 'gpt-4o-mini',
       messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'system', content: systemPrompt },
         { role: 'user', content: body.text },
       ],
       temperature: 0.3,


### PR DESCRIPTION
## Summary
- Adds a **Resume / Letter toggle** in the editor action bar so users can pick document type before formatting
- Button label adapts dynamically: **"Format My Resume"** or **"Format My Letter"**
- Server-side AI prompt is now type-specific: letter prompt produces a proper letter schema (`date`, `recipient`, `greeting`, `body/paragraph`, `closing`, `signature`); resume prompt unchanged
- Preview styles and DOMPurify allowlist updated to render cover-letter XML elements correctly

## Test plan
- [ ] Select **Resume**, paste a resume, click "Format My Resume" — formatted resume renders with name/contact/experience sections
- [ ] Select **Letter**, paste a cover letter, click "Format My Letter" — formatted letter renders with recipient block, greeting, body paragraphs, sign-off
- [ ] Toggle between Resume/Letter and confirm button label updates immediately
- [ ] Both document types print correctly (Export PDF)
- [ ] Lint passes (`npm run lint`)
- [ ] Build passes (`npm run build`)

Closes FRG-216

🤖 Generated with [Claude Code](https://claude.com/claude-code)