### PR TITLE
feat: Try Sample buttons for resume and letter examples (FRG-217)

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,6 +61,12 @@
               {{ validationMessage }}
             </p>
           </div>
+          <div class="sample-row">
+            <span class="sample-label">Try a sample:</span>
+            <button class="sample-link" :disabled="isFormatting" @click="loadSample('resume')">Resume</button>
+            <span class="sample-sep">·</span>
+            <button class="sample-link" :disabled="isFormatting" @click="loadSample('letter')">Letter</button>
+          </div>
         </div>
       </div>
 
@@ -97,6 +103,17 @@
         <!-- Empty state -->
         <div v-else-if="!formattedXml" class="preview-empty no-print">
           <p>Your formatted document will appear here.</p>
+          <p class="empty-hint">
+            New here? Try a sample:
+          </p>
+          <div class="sample-buttons">
+            <UButton variant="outline" size="sm" :disabled="isFormatting" @click="loadSample('resume')">
+              Try Resume Sample
+            </UButton>
+            <UButton variant="outline" size="sm" :disabled="isFormatting" @click="loadSample('letter')">
+              Try Letter Sample
+            </UButton>
+          </div>
         </div>
 
         <!-- Preview + review note -->
@@ -146,6 +163,15 @@ const showDivergenceWarning = computed(() => formattedXml.value && divergence.va
 
 function handlePrint() {
   window.print()
+}
+
+async function loadSample(type: 'resume' | 'letter') {
+  const filename = type === 'resume' ? 'resume-sample.txt' : 'letter-sample.txt'
+  const response = await fetch(`/samples/${filename}`)
+  const text = await response.text()
+  textContent.value = text
+  selectedDocType.value = type
+  formatDocument()
 }
 
 async function formatDocument() {
@@ -304,10 +330,61 @@ async function formatDocument() {
 .preview-empty {
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 0.5rem;
   color: var(--color-gray-400);
   font-size: 0.875rem;
+}
+
+.empty-hint {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--color-gray-400);
+}
+
+.sample-buttons {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.sample-row {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--color-gray-400);
+}
+
+.sample-label {
+  color: var(--color-gray-400);
+}
+
+.sample-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.78rem;
+  color: var(--color-gray-500);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.sample-link:hover:not(:disabled) {
+  color: var(--color-gray-800);
+}
+
+.sample-link:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sample-sep {
+  color: var(--color-gray-300);
 }
 
 /* ── Skeleton loading UI ── */

--- a/public/samples/letter-sample.txt
+++ b/public/samples/letter-sample.txt
@@ -1,0 +1,23 @@
+Jane Park
+jane.park@email.com | (647) 555-0290 | Vancouver, BC
+
+March 9, 2026
+
+Hiring Manager
+Acme Technology
+San Francisco, CA
+
+Dear Hiring Manager,
+
+I am writing to apply for the Product Designer position at Acme Technology. With five years of experience crafting user-centered digital products for startups and enterprise clients, I am excited by Acme's mission to make software more accessible for everyone.
+
+At Stripe, I led the redesign of the payment onboarding flow, reducing drop-off by 34% and improving first-payment conversion by 22%. I worked closely with engineering and product teams using Figma, conducting usability testing with 12+ participants per sprint cycle. My work earned an internal Design Excellence Award in 2024.
+
+Previously at Hootsuite, I redesigned the mobile scheduling experience for 18 million users, delivering a 4.8-star App Store rating after launch. I built and maintained the company's first design system, enabling 3 product teams to ship features 40% faster.
+
+I admire Acme's recent launch of the accessibility-first design toolkit and would love to contribute to this work. My background in inclusive design and WCAG compliance aligns closely with your team's values.
+
+Thank you for your time and consideration. I would welcome the chance to discuss how I can contribute to Acme's product vision. Please find my portfolio attached.
+
+Sincerely,
+Jane Park

--- a/public/samples/resume-sample.txt
+++ b/public/samples/resume-sample.txt
@@ -1,0 +1,40 @@
+Alex Morgan
+alex.morgan@email.com | (416) 555-0182 | Toronto, ON | linkedin.com/in/alexmorgan
+
+Senior Software Engineer with 7 years of experience building scalable web applications and APIs. Passionate about developer experience, clean architecture, and mentoring junior engineers.
+
+EXPERIENCE
+
+Senior Software Engineer — Shopify
+March 2021 – Present
+- Led migration of core checkout service from monolith to microservices, reducing p99 latency by 40%
+- Mentored 4 junior engineers through onboarding, code review, and career development
+- Designed and implemented real-time inventory sync feature serving 500K+ merchants
+- Drove adoption of TypeScript across 3 teams, eliminating 85% of runtime type errors
+
+Software Engineer — Wave Financial
+June 2018 – February 2021
+- Built automated reconciliation system processing $2B+ in transactions monthly
+- Improved API test coverage from 42% to 91%, reducing production incidents by 60%
+- Collaborated with design team to rebuild accounting dashboard, increasing user retention 23%
+- Optimized database queries, reducing report generation time from 12s to under 1.5s
+
+Junior Developer — FreshBooks
+September 2016 – May 2018
+- Developed new invoice customization features used by 200K+ small business customers
+- Fixed 150+ bugs across billing and payment systems in first year
+- Participated in on-call rotation, maintaining 99.9% uptime SLA
+
+EDUCATION
+
+Bachelor of Science, Computer Science
+University of Waterloo — 2016
+Dean's Honour List
+
+SKILLS
+
+JavaScript, TypeScript, Python, Ruby, Go, React, Node.js, PostgreSQL, Redis, AWS, Docker, Kubernetes, REST APIs, GraphQL, Git
+
+CERTIFICATIONS
+
+AWS Certified Solutions Architect – Associate (2022)


### PR DESCRIPTION
## Summary

- Adds **Try Resume Sample** and **Try Letter Sample** buttons to the empty state (right panel) so first-time visitors can explore OhMyDoc without bringing their own content
- Adds subtle **Try a sample: Resume · Letter** inline links in the action bar (left panel) for discoverability when the editor is already in use
- Creates two realistic plain-text sample files served statically from `/public/samples/`:
  - `resume-sample.txt` — Alex Morgan, Senior Software Engineer (Shopify, Wave, FreshBooks)
  - `letter-sample.txt` — Jane Park, Product Designer applying to Acme Technology
- `loadSample()` fetches the file, sets the doc type toggle, and auto-triggers `formatDocument()` — user sees a formatted result immediately

## How it works

1. User clicks **Try Resume Sample** (empty state or action bar link)
2. `loadSample('resume')` fetches `/samples/resume-sample.txt`
3. Text is loaded into the textarea, doc type set to Resume
4. `formatDocument()` is called automatically → skeleton → formatted preview

## Test plan

- [ ] Fresh page load: empty state shows "Try Resume Sample" and "Try Letter Sample" buttons
- [ ] Click **Try Resume Sample** → textarea fills with resume content, Resume toggle activates, skeleton appears, formatted resume renders
- [ ] Click **Try Letter Sample** → same flow with letter content and Letter toggle active
- [ ] Action bar "Try a sample: Resume · Letter" links are visible and functional at all times
- [ ] Sample buttons are disabled while formatting is in progress (no double-trigger)
- [ ] No regression: manual paste + Format My Resume still works as before

Closes FRG-217

🤖 Generated with [Claude Code](https://claude.com/claude-code)