### PR TITLE
feat(FRG-271): add SEO meta tags (title, OG, Twitter card)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,22 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ['@nuxt/eslint', '@nuxt/ui', '@vercel/analytics/nuxt'],
 
+  app: {
+    head: {
+      title: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF',
+      meta: [
+        { name: 'description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:url', content: 'https://ohmydoc.vercel.app' },
+        { property: 'og:title', content: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF' },
+        { property: 'og:description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF' },
+        { name: 'twitter:description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+      ],
+    },
+  },
+
   devServer: {
     port: 3002
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -174,7 +174,7 @@
 import { ref, computed } from 'vue'
 
 useHead({
-  title: 'OhMyDoc',
+  title: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF',
 })
 
 const placeholder = `Paste your resume or cover letter here.


### PR DESCRIPTION
## Summary
- Add `<title>` tag: `OhMyDoc — Free Resume Formatter | Paste → Format → PDF`
- Add `<meta name="description">` with app value
- Add OG tags: `og:type`, `og:url`, `og:title`, `og:description`
- Add Twitter Card tags: `twitter:card` (summary_large_image), `twitter:title`, `twitter:description`

## Implementation
- Global tags configured in `nuxt.config.ts` under `app.head`
- Updated `pages/index.vue` `useHead` title to match (was overriding the global config with the short "OhMyDoc" title)

## Test plan
- [x] All meta tags present in SSR page source (verified via curl on built output)
- [x] Title renders correctly: `OhMyDoc — Free Resume Formatter | Paste → Format → PDF`
- [x] No duplicate or conflicting meta tags
- [ ] Validate OG tags via https://www.opengraph.xyz after deployment

Closes FRG-271

🤖 Generated with [Claude Code](https://claude.com/claude-code)