### PR TITLE
feat: update SEO meta tags and landing page copy (FRG-272, FRG-273)

### DIFF
--- a/components/AppHeader.vue
+++ b/components/AppHeader.vue
@@ -4,7 +4,10 @@
       <!-- Brand -->
       <div class="brand">
         <span class="brand-name">OhMyDoc</span>
-        <span class="brand-tagline">Paste your resume or letter — get clean, professional formatting</span>
+        <div class="brand-copy">
+          <span class="brand-tagline">The Free Resume Formatter. Actually Free.</span>
+          <span class="brand-subheadline">Paste your plain text. Get a clean, ATS-friendly PDF instantly. No login, no paywalls, no BS. Just format and download.</span>
+        </div>
       </div>
 
       <!-- Right action slot -->
@@ -32,7 +35,7 @@
 
 .brand {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.75rem;
   min-width: 0;
 }
@@ -46,8 +49,25 @@
   flex-shrink: 0;
 }
 
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .brand-tagline {
   font-size: 0.75rem;
+  font-weight: 500;
+  color: #cbd5e1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.brand-subheadline {
+  font-size: 0.65rem;
   color: #64748b;
   white-space: nowrap;
   overflow: hidden;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,16 +6,16 @@ export default defineNuxtConfig({
 
   app: {
     head: {
-      title: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF',
+      title: 'OhMyDoc | Free Resume Formatter (No Sign Up, ATS-Friendly)',
       meta: [
-        { name: 'description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+        { name: 'description', content: 'The actually free resume formatter. Paste your text from ChatGPT or Google Docs, get an ATS-friendly PDF instantly. No paywalls, no login required. Open source.' },
         { property: 'og:type', content: 'website' },
         { property: 'og:url', content: 'https://ohmydoc.vercel.app' },
-        { property: 'og:title', content: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF' },
-        { property: 'og:description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+        { property: 'og:title', content: 'OhMyDoc | Free Resume Formatter (No Sign Up, ATS-Friendly)' },
+        { property: 'og:description', content: 'The actually free resume formatter. Paste your text from ChatGPT or Google Docs, get an ATS-friendly PDF instantly. No paywalls, no login required. Open source.' },
         { name: 'twitter:card', content: 'summary_large_image' },
-        { name: 'twitter:title', content: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF' },
-        { name: 'twitter:description', content: 'Paste your resume, get instant professional formatting, export to PDF. No signup, no AI rewriting, no paywall. Free and open source.' },
+        { name: 'twitter:title', content: 'OhMyDoc | Free Resume Formatter (No Sign Up, ATS-Friendly)' },
+        { name: 'twitter:description', content: 'The actually free resume formatter. Paste your text from ChatGPT or Google Docs, get an ATS-friendly PDF instantly. No paywalls, no login required. Open source.' },
       ],
     },
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -174,7 +174,7 @@
 import { ref, computed } from 'vue'
 
 useHead({
-  title: 'OhMyDoc — Free Resume Formatter | Paste → Format → PDF',
+  title: 'OhMyDoc | Free Resume Formatter (No Sign Up, ATS-Friendly)',
 })
 
 const placeholder = `Paste your resume or cover letter here.


### PR DESCRIPTION
## Summary
- **FRG-272**: Update title tag, meta description, OG, and Twitter card tags to target "free resume formatter" keywords
- **FRG-273**: Update AppHeader H1 tagline to "The Free Resume Formatter. Actually Free." and add subheadline "Paste your plain text. Get a clean, ATS-friendly PDF instantly. No login, no paywalls, no BS. Just format and download."

## Test plan
- [ ] Verify page title shows `OhMyDoc | Free Resume Formatter (No Sign Up, ATS-Friendly)` in browser tab
- [ ] Verify meta description is updated (check via DevTools > Elements > `<head>`)
- [ ] Verify OG and Twitter card meta tags are updated
- [ ] Verify AppHeader shows new tagline and subheadline in the brand area

🤖 Generated with [Claude Code](https://claude.com/claude-code)