### PR TITLE
feat(FRG-274): add ATS-Friendly badge and callout near download

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,6 +15,7 @@
           >
             Export PDF
           </UButton>
+          <span v-if="formattedXml" class="ats-badge">✅ ATS-Friendly</span>
           <span class="export-hint">Works best in Chrome. In the print dialog, choose 'Save as PDF'.</span>
         </div>
       </template>
@@ -87,6 +88,7 @@
                 {{ validationMessage }}
               </p>
             </div>
+            <p class="ats-callout">✅ ATS-Friendly Formatting — works with all major applicant tracking systems</p>
             <div class="sample-row">
               <span class="sample-label">Try a sample:</span>
               <button class="sample-link" :disabled="isFormatting" @click="loadSample('resume')">Resume</button>
@@ -621,6 +623,27 @@ async function formatDocument() {
   font-size: 0.7rem;
   color: #94a3b8;
   white-space: nowrap;
+}
+
+/* ── ATS-Friendly badge (in export header area) ── */
+.ats-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #15803d;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 99px;
+  padding: 0.2rem 0.55rem;
+  white-space: nowrap;
+  letter-spacing: 0.01em;
+}
+
+/* ── ATS-Friendly callout (in action bar below format button) ── */
+.ats-callout {
+  font-size: 0.775rem;
+  color: #16a34a;
+  margin: 0;
+  line-height: 1.4;
 }
 
 /* ── Divergence info (subtle, not alarming) ── */


### PR DESCRIPTION
## Summary
- Adds a **"✅ ATS-Friendly" pill badge** in the export header area, displayed alongside the Export PDF button once a document has been formatted
- Adds a **"✅ ATS-Friendly Formatting — works with all major applicant tracking systems"** callout in the action bar below the Format button, acting as a persistent trust signal for users before they submit

## Motivation
Users searching for resume formatting have anxiety about ATS compatibility. Explicitly calling it out near both the primary CTA (Format button) and the download action (Export PDF) removes friction and reinforces confidence at the two most critical moments in the user journey.

## Changes
- `pages/index.vue`: Added `.ats-badge` element (shown when `formattedXml` is set) in the export area, `.ats-callout` paragraph in the action bar, and corresponding scoped CSS for both

## Test plan
- [ ] Load the app at `/` — confirm the `.ats-callout` text is visible below the "Format My Resume" button
- [ ] Paste sample content and click Format — confirm formatted document appears
- [ ] Confirm "✅ ATS-Friendly" badge appears in the header next to Export PDF
- [ ] Verify neither element appears in print/PDF output (both are inside `.no-print` containers)
- [ ] Verify build passes (`npm run build`) ✅

Closes FRG-274

🤖 Generated with [Claude Code](https://claude.com/claude-code)